### PR TITLE
Refactor server aggregation and add coverage

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,61 @@
+package config
+
+import (
+	"encoding/hex"
+	"testing"
+	"time"
+)
+
+func TestDecodeHexKey(t *testing.T) {
+	input := make([]byte, 32)
+	for i := range input {
+		input[i] = byte(i)
+	}
+	hexKey := hex.EncodeToString(input)
+	decoded, err := decodeHexKey(hexKey)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(decoded) != string(input) {
+		t.Fatalf("expected %x but got %x", input, decoded)
+	}
+}
+
+func TestDecodeHexKeyInvalidLength(t *testing.T) {
+	if _, err := decodeHexKey("abcd"); err == nil {
+		t.Fatalf("expected error for invalid length")
+	}
+}
+
+func TestLoadDefaults(t *testing.T) {
+	t.Setenv("COMPASS_CREDENTIAL_KEY", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Server.Address != ":8080" {
+		t.Fatalf("expected default server address, got %q", cfg.Server.Address)
+	}
+	if cfg.Database.Path != "data/nomad-compass.sqlite" {
+		t.Fatalf("expected default database path, got %q", cfg.Database.Path)
+	}
+	if cfg.Nomad.Address != "http://127.0.0.1:4646" {
+		t.Fatalf("expected default nomad address, got %q", cfg.Nomad.Address)
+	}
+	if cfg.Repo.BaseDir != "data/repos" {
+		t.Fatalf("expected default repo base dir, got %q", cfg.Repo.BaseDir)
+	}
+	if cfg.Repo.PollInterval != 30*time.Second {
+		t.Fatalf("expected default poll interval, got %s", cfg.Repo.PollInterval)
+	}
+	if len(cfg.Crypto.CredentialKey) != 32 {
+		t.Fatalf("expected 32 byte key, got %d", len(cfg.Crypto.CredentialKey))
+	}
+}
+
+func TestLoadRequiresCredentialKey(t *testing.T) {
+	t.Setenv("COMPASS_CREDENTIAL_KEY", "")
+	if _, err := Load(); err == nil {
+		t.Fatalf("expected error when credential key is missing")
+	}
+}

--- a/internal/nomadclient/client_test.go
+++ b/internal/nomadclient/client_test.go
@@ -1,0 +1,72 @@
+package nomadclient
+
+import (
+	"testing"
+)
+
+func TestDeriveStatus(t *testing.T) {
+	cases := []struct {
+		name   string
+		status *JobStatus
+		want   string
+	}{
+		{name: "nil", status: nil, want: ""},
+		{name: "failed allocs", status: &JobStatus{FailedAllocs: 1}, want: "failed"},
+		{name: "lost allocs", status: &JobStatus{LostAllocs: 1}, want: "lost"},
+		{name: "healthy", status: &JobStatus{RunningAllocs: 2, DesiredAllocs: 2}, want: "healthy"},
+		{name: "degraded", status: &JobStatus{RunningAllocs: 1, DesiredAllocs: 2}, want: "degraded"},
+		{name: "deploying", status: &JobStatus{StartingAllocs: 1}, want: "deploying"},
+		{name: "pending", status: &JobStatus{Status: "pending"}, want: "pending"},
+		{name: "dead", status: &JobStatus{Status: "dead"}, want: "dead"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, _ := deriveStatus(tc.status)
+			if got != tc.want {
+				t.Fatalf("expected %q, got %q", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestFormatAllocationSummary(t *testing.T) {
+	status := &JobStatus{RunningAllocs: 3, DesiredAllocs: 5}
+	if got := formatAllocationSummary(status); got != "3/5 allocations running" {
+		t.Fatalf("unexpected summary: %s", got)
+	}
+	if got := formatAllocationSummary(nil); got != "" {
+		t.Fatalf("expected empty summary for nil status")
+	}
+}
+
+func TestDeriveStatusFromDeployment(t *testing.T) {
+	status := &JobStatus{RunningAllocs: 1, DesiredAllocs: 1}
+	if got, _ := deriveStatusFromDeployment(status, "successful"); got != "healthy" {
+		t.Fatalf("expected healthy for successful deployment, got %q", got)
+	}
+	if got, _ := deriveStatusFromDeployment(status, "running"); got != "deploying" {
+		t.Fatalf("expected deploying for running deployment, got %q", got)
+	}
+	if got, _ := deriveStatusFromDeployment(status, "failed"); got != "failed" {
+		t.Fatalf("expected failed for failed deployment, got %q", got)
+	}
+	if got, _ := deriveStatusFromDeployment(status, "unknown"); got != "" {
+		t.Fatalf("expected empty status for unknown deployment, got %q", got)
+	}
+}
+
+func TestDerefString(t *testing.T) {
+	primary := "value"
+	fallback := "fallback"
+	if got := derefString(&primary, &fallback); got != "value" {
+		t.Fatalf("expected primary value, got %q", got)
+	}
+	primary = ""
+	if got := derefString(&primary, &fallback); got != "fallback" {
+		t.Fatalf("expected fallback value, got %q", got)
+	}
+	if got := derefString(nil, nil); got != "" {
+		t.Fatalf("expected empty string when both nil")
+	}
+}

--- a/internal/server/repository.go
+++ b/internal/server/repository.go
@@ -1,0 +1,94 @@
+package server
+
+import (
+	"context"
+
+	"github.com/brianmichel/nomad-compass/internal/nomadclient"
+	"github.com/brianmichel/nomad-compass/internal/storage"
+)
+
+// listRepositoryResponses gathers repository information and augments it with
+// Nomad job details. The aggregation logic lives outside of the HTTP handler so
+// it can be reused by both tests and any future callers (e.g. scheduled cache
+// warmers) without going through net/http primitives.
+func (s *Server) listRepositoryResponses(ctx context.Context) ([]repositoryResponse, error) {
+	repos, err := s.repos.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	responses := make([]repositoryResponse, 0, len(repos))
+	for _, repo := range repos {
+		files, err := s.files.ListByRepo(ctx, repo.ID)
+		if err != nil {
+			return nil, err
+		}
+
+		jobResponses := make([]repositoryJobResponse, 0, len(files))
+		for _, file := range files {
+			jobResponses = append(jobResponses, s.buildJobResponse(ctx, repo, file))
+		}
+
+		repoResp := newRepositoryResponse(repo)
+		repoResp.Jobs = jobResponses
+		responses = append(responses, repoResp)
+	}
+
+	return responses, nil
+}
+
+func (s *Server) buildJobResponse(ctx context.Context, repo storage.Repository, file storage.RepoFile) repositoryJobResponse {
+	jobResp := newRepositoryJobResponse(file)
+	if !file.JobID.Valid || file.JobID.String == "" {
+		return jobResp
+	}
+
+	jobResp.JobID = file.JobID.String
+
+	status, err := s.nomad.JobStatus(ctx, file.JobID.String)
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Warn("fetch job status failed", "repo_id", repo.ID, "repo", repo.Name, "job_id", file.JobID.String, "error", err)
+		}
+		jobResp.StatusError = err.Error()
+		return jobResp
+	}
+	if status == nil {
+		return jobResp
+	}
+
+	if status.Exists {
+		applyNomadStatus(&jobResp, status, s.nomadAddr)
+	} else {
+		jobResp.Status = "missing"
+		jobResp.StatusDescription = "Job not found in Nomad"
+	}
+	return jobResp
+}
+
+// applyNomadStatus copies job health details from the Nomad API response onto
+// the JSON response model so the enrichment logic lives in one place.
+func applyNomadStatus(jobResp *repositoryJobResponse, status *nomadclient.JobStatus, nomadAddr string) {
+	jobResp.JobName = status.Name
+	jobResp.Status = status.DerivedStatus
+	if status.DerivedStatusReason != "" {
+		jobResp.StatusDescription = status.DerivedStatusReason
+	} else {
+		jobResp.StatusDescription = status.StatusDescription
+	}
+	jobResp.NomadStatus = status.Status
+	jobResp.Namespace = status.Namespace
+	jobResp.JobType = status.Type
+	jobResp.RunningAllocs = status.RunningAllocs
+	jobResp.DesiredAllocs = status.DesiredAllocs
+	jobResp.StartingAllocs = status.StartingAllocs
+	jobResp.QueuedAllocs = status.QueuedAllocs
+	jobResp.FailedAllocs = status.FailedAllocs
+	jobResp.LostAllocs = status.LostAllocs
+	jobResp.UnknownAllocs = status.UnknownAllocs
+	jobResp.LatestDeploymentID = status.LatestDeploymentID
+	jobResp.LatestAllocationID = status.LatestAllocationID
+	jobResp.LatestAllocationName = status.LatestAllocationName
+	jobResp.Allocations = status.Allocations
+	jobResp.JobURL = jobURL(nomadAddr, status.Namespace, status.ID)
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,280 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"testing"
+
+	"github.com/hashicorp/nomad/api"
+
+	"github.com/brianmichel/nomad-compass/internal/nomadclient"
+	"github.com/brianmichel/nomad-compass/internal/storage"
+)
+
+type fakeNomadClient struct {
+	statusByID map[string]*nomadclient.JobStatus
+	errByID    map[string]error
+	calls      []string
+}
+
+func (f *fakeNomadClient) RegisterJob(ctx context.Context, job *api.Job) error {
+	return nil
+}
+
+func (f *fakeNomadClient) DeregisterJob(ctx context.Context, jobID string, purge bool) error {
+	return nil
+}
+
+func (f *fakeNomadClient) Ping(ctx context.Context) error {
+	return nil
+}
+
+func (f *fakeNomadClient) JobStatus(ctx context.Context, jobID string) (*nomadclient.JobStatus, error) {
+	f.calls = append(f.calls, jobID)
+	if f.errByID != nil {
+		if err, ok := f.errByID[jobID]; ok {
+			return nil, err
+		}
+	}
+	if f.statusByID != nil {
+		if status, ok := f.statusByID[jobID]; ok {
+			return status, nil
+		}
+	}
+	return nil, nil
+}
+
+func setupServer(t *testing.T) (*Server, context.Context, *storage.RepoStore, *storage.RepoFileStore, *fakeNomadClient) {
+	t.Helper()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "test.sqlite")
+	db, err := storage.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := storage.Migrate(ctx, db); err != nil {
+		t.Fatalf("migrate db: %v", err)
+	}
+
+	repoStore := storage.NewRepoStore(db)
+	fileStore := storage.NewRepoFileStore(db)
+	nomad := &fakeNomadClient{}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	srv := &Server{
+		repos:     repoStore,
+		files:     fileStore,
+		nomad:     nomad,
+		logger:    logger,
+		nomadAddr: "http://nomad.local",
+	}
+	return srv, ctx, repoStore, fileStore, nomad
+}
+
+func TestListRepositoryResponsesWithoutJobStatus(t *testing.T) {
+	srv, ctx, repoStore, fileStore, nomad := setupServer(t)
+
+	repo, err := repoStore.Create(ctx, storage.RepositoryInput{
+		Name:    "demo",
+		RepoURL: "https://example.com/demo.git",
+		Branch:  "main",
+	})
+	if err != nil {
+		t.Fatalf("create repo: %v", err)
+	}
+
+	if err := fileStore.Upsert(ctx, repo.ID, "jobs/api.nomad", "abcd1234", ""); err != nil {
+		t.Fatalf("upsert file: %v", err)
+	}
+
+	responses, err := srv.listRepositoryResponses(ctx)
+	if err != nil {
+		t.Fatalf("list responses: %v", err)
+	}
+	if len(responses) != 1 {
+		t.Fatalf("expected 1 repo response, got %d", len(responses))
+	}
+	if len(responses[0].Jobs) != 1 {
+		t.Fatalf("expected 1 job response, got %d", len(responses[0].Jobs))
+	}
+
+	job := responses[0].Jobs[0]
+	if job.Path != "jobs/api.nomad" {
+		t.Fatalf("expected path jobs/api.nomad, got %s", job.Path)
+	}
+	if job.JobID != "" {
+		t.Fatalf("expected empty job id, got %s", job.JobID)
+	}
+	if len(nomad.calls) != 0 {
+		t.Fatalf("expected no nomad calls, got %v", nomad.calls)
+	}
+}
+
+func TestListRepositoryResponsesWithJobStatus(t *testing.T) {
+	srv, ctx, repoStore, fileStore, nomad := setupServer(t)
+
+	repo, err := repoStore.Create(ctx, storage.RepositoryInput{
+		Name:    "demo",
+		RepoURL: "https://example.com/demo.git",
+		Branch:  "main",
+	})
+	if err != nil {
+		t.Fatalf("create repo: %v", err)
+	}
+
+	if err := fileStore.Upsert(ctx, repo.ID, "jobs/api.nomad", "abcd1234", "job-123"); err != nil {
+		t.Fatalf("upsert file: %v", err)
+	}
+
+	nomad.statusByID = map[string]*nomadclient.JobStatus{
+		"job-123": {
+			ID:                   "job-123",
+			Name:                 "api",
+			Namespace:            "default",
+			Type:                 "service",
+			Status:               "running",
+			StatusDescription:    "Running",
+			DerivedStatus:        "healthy",
+			DesiredAllocs:        1,
+			RunningAllocs:        1,
+			LatestDeploymentID:   "deploy-1",
+			LatestAllocationID:   "alloc-1",
+			LatestAllocationName: "alloc-name",
+			Allocations:          []nomadclient.AllocationStatus{{ID: "alloc-1", Status: "running"}},
+			Exists:               true,
+		},
+	}
+
+	responses, err := srv.listRepositoryResponses(ctx)
+	if err != nil {
+		t.Fatalf("list responses: %v", err)
+	}
+	if len(responses) != 1 {
+		t.Fatalf("expected 1 repo response, got %d", len(responses))
+	}
+	if len(responses[0].Jobs) != 1 {
+		t.Fatalf("expected 1 job response, got %d", len(responses[0].Jobs))
+	}
+
+	job := responses[0].Jobs[0]
+	if job.JobID != "job-123" {
+		t.Fatalf("expected job id job-123, got %s", job.JobID)
+	}
+	if job.Status != "healthy" {
+		t.Fatalf("expected status healthy, got %s", job.Status)
+	}
+	if job.JobName != "api" {
+		t.Fatalf("expected job name api, got %s", job.JobName)
+	}
+	if job.JobType != "service" {
+		t.Fatalf("expected job type service, got %s", job.JobType)
+	}
+	expectedURL := "http://nomad.local/ui/jobs/job-123@default"
+	if job.JobURL != expectedURL {
+		t.Fatalf("expected job url %s, got %s", expectedURL, job.JobURL)
+	}
+	if len(job.Allocations) != 1 || job.Allocations[0].ID != "alloc-1" {
+		t.Fatalf("unexpected allocations: %+v", job.Allocations)
+	}
+	if len(nomad.calls) != 1 || nomad.calls[0] != "job-123" {
+		t.Fatalf("unexpected nomad calls: %v", nomad.calls)
+	}
+}
+
+func TestListRepositoryResponsesMissingJob(t *testing.T) {
+	srv, ctx, repoStore, fileStore, nomad := setupServer(t)
+
+	repo, err := repoStore.Create(ctx, storage.RepositoryInput{
+		Name:    "demo",
+		RepoURL: "https://example.com/demo.git",
+		Branch:  "main",
+	})
+	if err != nil {
+		t.Fatalf("create repo: %v", err)
+	}
+
+	if err := fileStore.Upsert(ctx, repo.ID, "jobs/api.nomad", "abcd1234", "job-123"); err != nil {
+		t.Fatalf("upsert file: %v", err)
+	}
+
+	nomad.statusByID = map[string]*nomadclient.JobStatus{
+		"job-123": {ID: "job-123", Exists: false},
+	}
+
+	responses, err := srv.listRepositoryResponses(ctx)
+	if err != nil {
+		t.Fatalf("list responses: %v", err)
+	}
+	if len(responses) != 1 {
+		t.Fatalf("expected 1 repo response, got %d", len(responses))
+	}
+	job := responses[0].Jobs[0]
+	if job.Status != "missing" {
+		t.Fatalf("expected status missing, got %s", job.Status)
+	}
+	if job.StatusDescription != "Job not found in Nomad" {
+		t.Fatalf("unexpected status description: %s", job.StatusDescription)
+	}
+}
+
+func TestListRepositoryResponsesPropagatesErrors(t *testing.T) {
+	errStore := errors.New("store error")
+	srv := &Server{
+		repos: &staticRepoStore{repos: []storage.Repository{{ID: 1}}, err: nil},
+		files: &failingRepoFileStore{err: errStore},
+		nomad: &fakeNomadClient{},
+	}
+	_, err := srv.listRepositoryResponses(context.Background())
+	if !errors.Is(err, errStore) {
+		t.Fatalf("expected error %v, got %v", errStore, err)
+	}
+}
+
+func TestJobURL(t *testing.T) {
+	cases := []struct {
+		name      string
+		base      string
+		namespace string
+		jobID     string
+		expected  string
+	}{
+		{name: "empty base", jobID: "job-1", expected: ""},
+		{name: "empty job", base: "http://nomad.local", expected: ""},
+		{name: "default namespace", base: "http://nomad.local/", jobID: "job-1", expected: "http://nomad.local/ui/jobs/job-1@default"},
+		{name: "custom namespace", base: "http://nomad.local", namespace: "team-a", jobID: "job-1", expected: "http://nomad.local/ui/jobs/job-1@team-a"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := jobURL(tc.base, tc.namespace, tc.jobID); got != tc.expected {
+				t.Fatalf("expected %s, got %s", tc.expected, got)
+			}
+		})
+	}
+}
+
+type staticRepoStore struct {
+	repos []storage.Repository
+	err   error
+}
+
+func (s *staticRepoStore) List(ctx context.Context) ([]storage.Repository, error) {
+	return s.repos, s.err
+}
+
+func (s *staticRepoStore) Create(ctx context.Context, input storage.RepositoryInput) (*storage.Repository, error) {
+	return nil, errors.New("not implemented")
+}
+
+type failingRepoFileStore struct {
+	err error
+}
+
+func (f *failingRepoFileStore) ListByRepo(ctx context.Context, repoID int64) ([]storage.RepoFile, error) {
+	return nil, f.err
+}

--- a/internal/web/dist/.keep
+++ b/internal/web/dist/.keep
@@ -1,0 +1,1 @@
+Placeholder to satisfy go:embed during tests; real assets are built in CI.


### PR DESCRIPTION
## Summary
- refactor the HTTP server to depend on small interfaces and extract repository aggregation helpers
- add focused unit tests for server job presentation, configuration loading, and Nomad status helpers
- include a placeholder web asset so go:embed works during tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e8f949c614832ab42d9c7c097e9b56