### PR TITLE
Refactor frontend state management and styling utilities

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,8 +13,10 @@
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^5.0.0",
+        "jsdom": "^24.0.0",
         "typescript": "^5.3.0",
-        "vite": "^5.0.0"
+        "vite": "^5.0.0",
+        "vitest": "^1.4.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "vue": "^3.4.21",
@@ -13,7 +14,9 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.0.0",
+    "jsdom": "^24.0.0",
     "typescript": "^5.3.0",
-    "vite": "^5.0.0"
+    "vite": "^5.0.0",
+    "vitest": "^1.4.0"
   }
 }

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -29,12 +29,13 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref, watch, onBeforeUnmount } from 'vue';
-import Topbar from './components/Topbar.vue';
-import ToastMessage from './components/ToastMessage.vue';
-import RepoForm from './components/RepoForm.vue';
-import { useCompassStore } from './composables/useCompassStore';
-import type { RepoPayload } from './composables/useCompassStore';
+import { onMounted, ref } from 'vue';
+import Topbar from '@/components/Topbar.vue';
+import ToastMessage from '@/components/ToastMessage.vue';
+import RepoForm from '@/components/RepoForm.vue';
+import { useCompassStore } from '@/composables/useCompassStore';
+import { useBodyScrollLock } from '@/composables/useBodyScrollLock';
+import type { RepoPayload } from '@/types';
 
 const {
   refreshAll,
@@ -49,19 +50,10 @@ const {
 const showRepoModal = ref(false);
 const repoFormRef = ref<InstanceType<typeof RepoForm> | null>(null);
 
+useBodyScrollLock(showRepoModal);
+
 onMounted(() => {
   refreshAll();
-});
-
-watch(showRepoModal, (value) => {
-  if (typeof document === 'undefined') return;
-  document.body.style.overflow = value ? 'hidden' : '';
-});
-
-onBeforeUnmount(() => {
-  if (typeof document !== 'undefined') {
-    document.body.style.overflow = '';
-  }
 });
 
 function openRepoModal() {
@@ -127,18 +119,18 @@ function closeRepoModal() {
   top: 0.75rem;
   right: 0.75rem;
   z-index: 1;
-  border-radius: 999px;
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  background: rgba(15, 23, 42, 0.75);
-  color: rgba(226, 232, 240, 0.85);
-  transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--color-border-strong);
+  background: var(--color-surface-strong);
+  color: var(--color-text-secondary);
+  transition: border-color var(--transition-fast), background var(--transition-fast), color var(--transition-fast);
 }
 
 .close-button:hover,
 .close-button:focus-visible {
-  border-color: rgba(148, 163, 184, 0.55);
+  border-color: var(--color-border);
   background: rgba(30, 41, 59, 0.85);
-  color: rgba(226, 232, 240, 0.95);
+  color: var(--color-text-primary);
 }
 
 .fade-enter-active,

--- a/frontend/src/components/CredentialList.vue
+++ b/frontend/src/components/CredentialList.vue
@@ -32,7 +32,7 @@
 </template>
 
 <script setup lang="ts">
-import type { Credential } from '../composables/useCompassStore';
+import type { Credential } from '@/types';
 
 defineProps<{
   credentials: Credential[];

--- a/frontend/src/components/RepoForm.vue
+++ b/frontend/src/components/RepoForm.vue
@@ -45,11 +45,11 @@
 
 <script setup lang="ts">
 import { reactive } from 'vue';
-import type { Credential } from '../composables/useCompassStore';
+import type { Credential, RepoPayload } from '@/types';
 
 const props = defineProps<{ credentials: Credential[]; saving: boolean }>();
 const emit = defineEmits<{
-  (e: 'submit', payload: { name: string; repo_url: string; branch: string; job_path: string; credential_id?: number }): void;
+  (e: 'submit', payload: RepoPayload): void;
 }>();
 
 const form = reactive({

--- a/frontend/src/components/RepoJob.vue
+++ b/frontend/src/components/RepoJob.vue
@@ -42,7 +42,7 @@
 </template>
 
 <script setup lang="ts">
-import type { RepoJob, AllocationStatus } from '../composables/useCompassStore';
+import type { RepoJob, AllocationStatus } from '@/types';
 
 defineProps<{
   job: RepoJob;

--- a/frontend/src/components/RepoJobList.vue
+++ b/frontend/src/components/RepoJobList.vue
@@ -31,7 +31,7 @@
 <script setup lang="ts">
 import { ref, onMounted, onBeforeUnmount, watch, nextTick } from 'vue';
 import RepoJob from './RepoJob.vue';
-import type { RepoJob as RepoJobType } from '../composables/useCompassStore';
+import type { RepoJob as RepoJobType } from '@/types';
 
 const props = defineProps<{
   jobs: RepoJobType[];

--- a/frontend/src/components/RepoList.vue
+++ b/frontend/src/components/RepoList.vue
@@ -16,7 +16,7 @@
 
 <script setup lang="ts">
 import RepoCard from './RepoCard.vue';
-import type { Repo } from '../composables/useCompassStore';
+import type { Repo } from '@/types';
 
 defineProps<{
   repos: Repo[];

--- a/frontend/src/components/Topbar.vue
+++ b/frontend/src/components/Topbar.vue
@@ -30,7 +30,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue';
-import type { CompassStatus } from '../composables/useCompassStore';
+import type { CompassStatus } from '@/types';
 
 const props = defineProps<{
   status: CompassStatus | null;

--- a/frontend/src/composables/useBodyScrollLock.ts
+++ b/frontend/src/composables/useBodyScrollLock.ts
@@ -1,0 +1,20 @@
+import { onBeforeUnmount, watch } from 'vue';
+
+export function useBodyScrollLock(source: { value: boolean }) {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  const stop = watch(
+    () => source.value,
+    (value) => {
+      document.body.style.overflow = value ? 'hidden' : '';
+    },
+    { immediate: true },
+  );
+
+  onBeforeUnmount(() => {
+    stop();
+    document.body.style.overflow = '';
+  });
+}

--- a/frontend/src/composables/useCompassStore.ts
+++ b/frontend/src/composables/useCompassStore.ts
@@ -1,105 +1,49 @@
 import { reactive, toRefs } from 'vue';
+import {
+  createCredential as requestCreateCredential,
+  createRepo as requestCreateRepo,
+  fetchCredentials,
+  fetchRepos,
+  fetchStatus,
+  removeCredential,
+  removeRepo,
+  triggerRepoReconcile,
+} from '@/services/compassApi';
+import type {
+  CompassStatus,
+  Credential,
+  CredentialPayload,
+  DeleteCredentialOptions,
+  DeleteRepoOptions,
+  Repo,
+  RepoPayload,
+} from '@/types';
+import { ApiError } from '@/services/http';
 
-type Credential = {
-  id: number;
-  name: string;
-  type: string;
-  created_at?: string;
-  updated_at?: string;
-};
+interface CompassState {
+  credentials: Credential[];
+  repos: Repo[];
+  status: CompassStatus | null;
+  error: string | null;
+  refreshing: boolean;
+  savingCredential: boolean;
+  savingRepo: boolean;
+  syncingRepoId: number | null;
+  deletingRepoId: number | null;
+  deletingCredentialId: number | null;
+}
 
-type Repo = {
-  id: number;
-  name: string;
-  repo_url: string;
-  branch: string;
-  job_path: string;
-  credential_id?: number | null;
-  last_commit?: string | null;
-  last_commit_author?: string | null;
-  last_commit_title?: string | null;
-  last_polled_at?: string | null;
-  jobs: RepoJob[];
-};
-
-type RepoJob = {
-  path: string;
-  job_id?: string;
-  job_name?: string;
-  namespace?: string;
-  job_type?: string;
-  last_commit?: string | null;
-  updated_at: string;
-  status?: string;
-  status_description?: string;
-  status_error?: string;
-  nomad_status?: string;
-  desired_allocations?: number;
-  running_allocations?: number;
-  starting_allocations?: number;
-  queued_allocations?: number;
-  failed_allocations?: number;
-  lost_allocations?: number;
-  unknown_allocations?: number;
-  latest_deployment_id?: string;
-  latest_allocation_id?: string;
-  latest_allocation_name?: string;
-  job_url?: string;
-  allocations?: AllocationStatus[];
-};
-
-type AllocationStatus = {
-  id: string;
-  name?: string;
-  client?: string;
-  status?: string;
-  desired?: string;
-  group?: string;
-  healthy?: boolean | null;
-};
-
-type CredentialPayload = {
-  name: string;
-  type: string;
-  token?: string;
-  username?: string;
-  private_key?: string;
-  passphrase?: string;
-};
-
-type RepoPayload = {
-  name: string;
-  repo_url: string;
-  branch: string;
-  job_path: string;
-  credential_id?: number;
-};
-
-type DeleteCredentialOptions = {
-  deleteRepos: boolean;
-  unschedule: boolean;
-};
-
-type DeleteRepoOptions = {
-  unschedule: boolean;
-};
-
-type CompassStatus = {
-  nomad_connected: boolean;
-  nomad_message?: string;
-};
-
-const state = reactive({
-  credentials: [] as Credential[],
-  repos: [] as Repo[],
-  status: null as CompassStatus | null,
-  error: null as string | null,
+const state = reactive<CompassState>({
+  credentials: [],
+  repos: [],
+  status: null,
+  error: null,
   refreshing: false,
   savingCredential: false,
   savingRepo: false,
-  syncingRepoId: null as number | null,
-  deletingRepoId: null as number | null,
-  deletingCredentialId: null as number | null,
+  syncingRepoId: null,
+  deletingRepoId: null,
+  deletingCredentialId: null,
 });
 
 async function refreshAll() {
@@ -115,19 +59,11 @@ async function refreshAll() {
 }
 
 async function loadCredentials() {
-  const res = await fetch('/api/credentials');
-  if (!res.ok) {
-    throw new Error('Unable to load credentials');
-  }
-  state.credentials = await res.json();
+  state.credentials = await fetchCredentials();
 }
 
 async function loadRepos() {
-  const res = await fetch('/api/repos');
-  if (!res.ok) {
-    throw new Error('Unable to load repositories');
-  }
-  const repos: Repo[] = await res.json();
+  const repos = await fetchRepos();
   state.repos = repos.map((repo) => ({
     ...repo,
     jobs: repo.jobs ?? [],
@@ -135,25 +71,13 @@ async function loadRepos() {
 }
 
 async function loadStatus() {
-  const res = await fetch('/api/status');
-  if (!res.ok) {
-    throw new Error('Unable to load Nomad status');
-  }
-  state.status = await res.json();
+  state.status = await fetchStatus();
 }
 
 async function createCredential(payload: CredentialPayload) {
   try {
     state.savingCredential = true;
-    const res = await fetch('/api/credentials', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
-    });
-    if (!res.ok) {
-      const body = await safeJson(res);
-      throw new Error(body?.error || 'Failed to create credential');
-    }
+    await requestCreateCredential(payload);
     await loadCredentials();
   } catch (err) {
     setError(err);
@@ -166,18 +90,7 @@ async function createCredential(payload: CredentialPayload) {
 async function deleteCredential(id: number, options: DeleteCredentialOptions) {
   try {
     state.deletingCredentialId = id;
-    const res = await fetch(`/api/credentials/${id}`, {
-      method: 'DELETE',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        delete_repos: options.deleteRepos,
-        unschedule: options.unschedule,
-      }),
-    });
-    if (!res.ok) {
-      const body = await safeJson(res);
-      throw new Error(body?.error || 'Failed to delete credential');
-    }
+    await removeCredential(id, options);
     await refreshAll();
   } catch (err) {
     setError(err);
@@ -190,19 +103,9 @@ async function deleteCredential(id: number, options: DeleteCredentialOptions) {
 async function createRepo(payload: RepoPayload) {
   try {
     state.savingRepo = true;
-    const res = await fetch('/api/repos', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
-    });
-    let createdRepo: Repo | null = null;
-    if (!res.ok) {
-      const body = await safeJson(res);
-      throw new Error(body?.error || 'Failed to create repository');
-    }
-    createdRepo = (await res.json()) as Repo;
+    const createdRepo = await requestCreateRepo(payload);
     await loadRepos();
-    if (createdRepo) {
+    if (createdRepo?.id) {
       await waitForRepoJobs(createdRepo.id);
     }
   } catch (err) {
@@ -216,11 +119,7 @@ async function createRepo(payload: RepoPayload) {
 async function triggerReconcile(id: number) {
   try {
     state.syncingRepoId = id;
-    const res = await fetch(`/api/repos/${id}/reconcile`, { method: 'POST' });
-    if (!res.ok) {
-      const body = await safeJson(res);
-      throw new Error(body?.error || 'Failed to trigger reconcile');
-    }
+    await triggerRepoReconcile(id);
     await loadRepos();
   } catch (err) {
     setError(err);
@@ -233,15 +132,7 @@ async function triggerReconcile(id: number) {
 async function deleteRepo(id: number, options: DeleteRepoOptions) {
   try {
     state.deletingRepoId = id;
-    const res = await fetch(`/api/repos/${id}`, {
-      method: 'DELETE',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ unschedule: options.unschedule }),
-    });
-    if (!res.ok) {
-      const body = await safeJson(res);
-      throw new Error(body?.error || 'Failed to delete repository');
-    }
+    await removeRepo(id, options);
     await loadRepos();
   } catch (err) {
     setError(err);
@@ -256,20 +147,14 @@ function clearError() {
 }
 
 function setError(err: unknown) {
-  if (err instanceof Error) {
+  if (err instanceof ApiError) {
+    state.error = err.message;
+  } else if (err instanceof Error) {
     state.error = err.message;
   } else if (typeof err === 'string') {
     state.error = err;
   } else {
     state.error = 'Unexpected error';
-  }
-}
-
-async function safeJson(res: Response) {
-  try {
-    return await res.json();
-  } catch {
-    return null;
   }
 }
 
@@ -289,8 +174,6 @@ export function useCompassStore() {
     setError,
   };
 }
-
-export type { Credential, Repo, RepoJob, AllocationStatus, RepoPayload, CompassStatus };
 
 async function waitForRepoJobs(repoId: number) {
   const maxAttempts = 6;

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,8 +1,8 @@
 import { createApp } from 'vue';
-import App from './App.vue';
-import { router } from './router';
+import App from '@/App.vue';
+import { router } from '@/router';
 
-import './style.css';
+import '@/style.css';
 
 const app = createApp(App);
 app.use(router);

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -4,12 +4,12 @@ const routes = [
   {
     path: '/',
     name: 'dashboard',
-    component: () => import('./views/DashboardView.vue'),
+    component: () => import('@/views/DashboardView.vue'),
   },
   {
     path: '/settings',
     name: 'settings',
-    component: () => import('./views/SettingsView.vue'),
+    component: () => import('@/views/SettingsView.vue'),
   },
   {
     path: '/:pathMatch(.*)*',

--- a/frontend/src/services/compassApi.ts
+++ b/frontend/src/services/compassApi.ts
@@ -1,0 +1,61 @@
+import { httpRequest } from './http';
+import type {
+  CompassStatus,
+  Credential,
+  CredentialPayload,
+  DeleteCredentialOptions,
+  DeleteRepoOptions,
+  Repo,
+  RepoPayload,
+} from '@/types';
+
+const API_BASE = '/api';
+
+export function fetchCredentials() {
+  return httpRequest<Credential[]>(`${API_BASE}/credentials`);
+}
+
+export function createCredential(payload: CredentialPayload) {
+  return httpRequest<void>(`${API_BASE}/credentials`, {
+    method: 'POST',
+    json: payload,
+  });
+}
+
+export function removeCredential(id: number, options: DeleteCredentialOptions) {
+  return httpRequest<void>(`${API_BASE}/credentials/${id}`, {
+    method: 'DELETE',
+    json: {
+      delete_repos: options.deleteRepos,
+      unschedule: options.unschedule,
+    },
+  });
+}
+
+export function fetchRepos() {
+  return httpRequest<Repo[]>(`${API_BASE}/repos`);
+}
+
+export function createRepo(payload: RepoPayload) {
+  return httpRequest<Repo>(`${API_BASE}/repos`, {
+    method: 'POST',
+    json: payload,
+  });
+}
+
+export function removeRepo(id: number, options: DeleteRepoOptions) {
+  return httpRequest<void>(`${API_BASE}/repos/${id}`, {
+    method: 'DELETE',
+    json: { unschedule: options.unschedule },
+  });
+}
+
+export function triggerRepoReconcile(id: number) {
+  return httpRequest<void>(`${API_BASE}/repos/${id}/reconcile`, {
+    method: 'POST',
+  });
+}
+
+export function fetchStatus() {
+  return httpRequest<CompassStatus>(`${API_BASE}/status`);
+}

--- a/frontend/src/services/http.ts
+++ b/frontend/src/services/http.ts
@@ -1,0 +1,68 @@
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly payload?: unknown,
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
+export interface HttpOptions extends RequestInit {
+  json?: unknown;
+}
+
+export async function httpRequest<T = unknown>(input: RequestInfo | URL, options: HttpOptions = {}): Promise<T> {
+  const { json, headers, ...init } = options;
+  const finalHeaders = new Headers(headers ?? {});
+
+  if (json !== undefined) {
+    if (!finalHeaders.has('Content-Type')) {
+      finalHeaders.set('Content-Type', 'application/json');
+    }
+    init.body = JSON.stringify(json);
+  }
+
+  const response = await fetch(input, { ...init, headers: finalHeaders });
+  const data = await parseJson(response);
+
+  if (!response.ok) {
+    const message = extractErrorMessage(response, data);
+    throw new ApiError(message, response.status, data);
+  }
+
+  return data as T;
+}
+
+async function parseJson(response: Response) {
+  if (response.status === 204 || response.headers.get('content-length') === '0') {
+    return undefined;
+  }
+
+  const contentType = response.headers.get('content-type');
+  if (!contentType || !contentType.includes('application/json')) {
+    return undefined;
+  }
+
+  try {
+    return await response.json();
+  } catch {
+    return undefined;
+  }
+}
+
+function extractErrorMessage(response: Response, data: unknown) {
+  if (data && typeof data === 'object' && 'error' in data) {
+    const error = (data as { error?: unknown }).error;
+    if (typeof error === 'string' && error.trim()) {
+      return error;
+    }
+  }
+
+  if (response.statusText) {
+    return response.statusText;
+  }
+
+  return 'Request failed';
+}

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,9 +1,53 @@
 :root {
   color-scheme: dark;
   font-family: 'Inter', 'SF Pro Text', 'Segoe UI', sans-serif;
-  background-color: #020617;
-  color: #e2e8f0;
   line-height: 1.5;
+  background-color: var(--color-bg);
+  color: var(--color-text-primary);
+
+  --color-bg: #020617;
+  --color-surface: rgba(15, 23, 42, 0.78);
+  --color-surface-strong: rgba(15, 23, 42, 0.88);
+  --color-surface-muted: rgba(15, 23, 42, 0.65);
+  --color-glass: rgba(15, 23, 42, 0.72);
+
+  --color-border: rgba(148, 163, 184, 0.2);
+  --color-border-strong: rgba(148, 163, 184, 0.35);
+  --color-border-soft: rgba(148, 163, 184, 0.18);
+
+  --color-text-primary: #e2e8f0;
+  --color-text-secondary: rgba(148, 163, 184, 0.85);
+  --color-text-tertiary: rgba(148, 163, 184, 0.7);
+  --color-text-subtle: rgba(148, 163, 184, 0.6);
+
+  --color-primary: #2563eb;
+  --color-primary-soft: #7c3aed;
+  --color-primary-surface: rgba(59, 130, 246, 0.18);
+  --color-primary-border: rgba(129, 140, 248, 0.35);
+
+  --color-success: #34d399;
+  --color-success-surface: rgba(34, 197, 94, 0.15);
+  --color-success-border: rgba(34, 197, 94, 0.35);
+
+  --color-danger: #f87171;
+  --color-danger-surface: rgba(248, 113, 113, 0.2);
+  --color-danger-border: rgba(248, 113, 113, 0.4);
+
+  --shadow-lg: 0 25px 60px -40px rgba(15, 23, 42, 0.7);
+  --shadow-glass: 0 20px 55px -35px rgba(2, 6, 23, 0.85);
+  --shadow-button-primary: 0 15px 30px -15px rgba(37, 99, 235, 0.65);
+  --shadow-button-primary-hover: 0 18px 35px -15px rgba(129, 140, 248, 0.55);
+  --shadow-danger: 0 18px 45px -25px rgba(248, 113, 113, 0.55);
+
+  --radius-lg: 20px;
+  --radius-xl: 24px;
+  --radius-md: 12px;
+  --radius-sm: 10px;
+  --radius-pill: 999px;
+
+  --transition-base: 0.2s ease;
+  --transition-fast: 0.15s ease;
+  --backdrop-blur: blur(18px);
 }
 
 *, *::before, *::after {
@@ -17,12 +61,18 @@ body {
     radial-gradient(120vw 120vh at -20% -10%, rgba(59, 130, 246, 0.35), transparent 60%),
     radial-gradient(80vw 80vh at 120% -10%, rgba(192, 38, 211, 0.25), transparent 70%),
     radial-gradient(120vw 120vh at 50% 110%, rgba(56, 189, 248, 0.2), transparent 75%),
-    #020617;
+    var(--color-bg);
+  color: var(--color-text-primary);
 }
 
 a {
   color: inherit;
   text-decoration: none;
+  transition: color var(--transition-base);
+}
+
+a:hover {
+  color: var(--color-text-secondary);
 }
 
 button {
@@ -34,11 +84,11 @@ select,
 textarea {
   font: inherit;
   color: inherit;
-  background-color: rgba(15, 23, 42, 0.85);
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  border-radius: 10px;
+  background-color: var(--color-surface-muted);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
   padding: 0.65rem 0.75rem;
-  transition: border 0.2s ease, box-shadow 0.2s ease;
+  transition: border var(--transition-base), box-shadow var(--transition-base);
 }
 
 input:focus,
@@ -57,12 +107,13 @@ textarea {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 1.25rem;
   padding: 1rem 1.5rem;
-  border-radius: 20px;
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  background: rgba(15, 23, 42, 0.72);
-  backdrop-filter: blur(18px);
-  box-shadow: 0 25px 60px -40px rgba(15, 23, 42, 0.7);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  background: var(--color-glass);
+  backdrop-filter: var(--backdrop-blur);
+  box-shadow: var(--shadow-lg);
 }
 
 .brand {
@@ -79,7 +130,7 @@ textarea {
   font-size: 1.5rem;
   border-radius: 14px;
   background: linear-gradient(145deg, rgba(59, 130, 246, 0.45), rgba(14, 116, 144, 0.4));
-  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.2);
+  box-shadow: inset 0 0 0 1px var(--color-border);
 }
 
 .brand-copy {
@@ -95,7 +146,33 @@ textarea {
 
 .brand-subtitle {
   font-size: 0.85rem;
-  color: rgba(148, 163, 184, 0.8);
+  color: var(--color-text-tertiary);
+}
+
+.topbar-nav {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.nav-link {
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: rgba(226, 232, 240, 0.75);
+  padding: 0.35rem 0.75rem;
+  border-radius: var(--radius-pill);
+  transition: background-color var(--transition-base), color var(--transition-base);
+}
+
+.nav-link:hover {
+  color: rgba(226, 232, 240, 0.95);
+  background: var(--color-primary-surface);
+}
+
+.nav-link.active {
+  color: #c7d2fe;
+  background: rgba(99, 102, 241, 0.25);
+  border: 1px solid var(--color-primary-border);
 }
 
 .topbar-actions {
@@ -110,15 +187,15 @@ textarea {
   gap: 0.5rem;
   font-size: 0.85rem;
   padding: 0.3rem 0.75rem;
-  border-radius: 999px;
-  background: rgba(34, 197, 94, 0.15);
-  border: 1px solid rgba(34, 197, 94, 0.35);
+  border-radius: var(--radius-pill);
+  background: var(--color-success-surface);
+  border: 1px solid var(--color-success-border);
   color: #bbf7d0;
 }
 
 .status-badge.offline {
-  background: rgba(248, 113, 113, 0.2);
-  border: 1px solid rgba(248, 113, 113, 0.4);
+  background: var(--color-danger-surface);
+  border: 1px solid var(--color-danger-border);
   color: #fecaca;
 }
 
@@ -126,13 +203,13 @@ textarea {
   width: 9px;
   height: 9px;
   border-radius: 50%;
-  background: #34d399;
+  background: var(--color-success);
   box-shadow: 0 0 0 0 rgba(52, 211, 153, 0.7);
   animation: pulse 2s infinite;
 }
 
 .pulse.offline {
-  background: #f87171;
+  background: var(--color-danger);
   box-shadow: 0 0 0 0 rgba(248, 113, 113, 0.7);
   animation: pulse-offline 2s infinite;
 }
@@ -163,14 +240,14 @@ textarea {
 
 .panel {
   padding: 1.75rem;
-  border-radius: 22px;
+  border-radius: var(--radius-xl);
 }
 
 .glass {
-  background: rgba(15, 23, 42, 0.78);
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  box-shadow: 0 20px 55px -35px rgba(2, 6, 23, 0.85);
-  backdrop-filter: blur(18px);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border-soft);
+  box-shadow: var(--shadow-glass);
+  backdrop-filter: var(--backdrop-blur);
 }
 
 .panel-header {
@@ -188,9 +265,9 @@ textarea {
 }
 
 .panel-header p {
-  margin: 0.2rem 0 0 0;
+  margin: 0.2rem 0 0;
   font-size: 0.9rem;
-  color: rgba(148, 163, 184, 0.9);
+  color: var(--color-text-secondary);
 }
 
 .form-grid {
@@ -205,13 +282,20 @@ textarea {
   flex-direction: column;
   gap: 0.5rem;
   font-weight: 500;
-  color: #e2e8f0;
+  color: var(--color-text-primary);
   font-size: 0.95rem;
+}
+
+.field span {
+  font-size: 0.82rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-text-tertiary);
 }
 
 .field small {
   font-weight: 400;
-  color: rgba(148, 163, 184, 0.8);
+  color: var(--color-text-tertiary);
 }
 
 .field.full {
@@ -222,11 +306,11 @@ button {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
-  border-radius: 12px;
+  border-radius: var(--radius-md);
   border: none;
   font-weight: 600;
   cursor: pointer;
-  transition: transform 0.15s ease, box-shadow 0.15s ease, opacity 0.15s ease;
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast), opacity var(--transition-fast);
 }
 
 button:disabled {
@@ -238,20 +322,20 @@ button:disabled {
 
 .primary {
   justify-self: flex-start;
-  background: linear-gradient(135deg, #2563eb, #7c3aed);
+  background: linear-gradient(135deg, var(--color-primary), var(--color-primary-soft));
   color: white;
   padding: 0.7rem 1.4rem;
-  box-shadow: 0 15px 30px -15px rgba(37, 99, 235, 0.65);
+  box-shadow: var(--shadow-button-primary);
 }
 
 .primary:hover:not(:disabled) {
   transform: translateY(-1px);
-  box-shadow: 0 18px 35px -15px rgba(129, 140, 248, 0.55);
+  box-shadow: var(--shadow-button-primary-hover);
 }
 
 .ghost {
   background: rgba(15, 23, 42, 0.55);
-  border: 1px solid rgba(148, 163, 184, 0.25);
+  border: 1px solid var(--color-border);
   color: rgba(226, 232, 240, 0.95);
   padding: 0.55rem 1rem;
 }
@@ -266,12 +350,12 @@ button:disabled {
 }
 
 .ghost.danger {
-  border-color: rgba(248, 113, 113, 0.35);
+  border-color: var(--color-danger-border);
   color: #fecaca;
 }
 
 .ghost.danger:hover:not(:disabled) {
-  box-shadow: 0 12px 25px -15px rgba(248, 113, 113, 0.45);
+  box-shadow: var(--shadow-danger);
 }
 
 .button-icon {
@@ -320,9 +404,9 @@ button:disabled {
 }
 
 .credential-row p {
-  margin: 0.2rem 0 0 0;
+  margin: 0.2rem 0 0;
   font-size: 0.85rem;
-  color: rgba(148, 163, 184, 0.85);
+  color: var(--color-text-secondary);
 }
 
 .row-actions {
@@ -333,11 +417,11 @@ button:disabled {
 
 .pill {
   padding: 0.3rem 0.75rem;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  background: rgba(59, 130, 246, 0.18);
+  background: var(--color-primary-surface);
   border: 1px solid rgba(59, 130, 246, 0.35);
   color: #bfdbfe;
 }
@@ -355,121 +439,6 @@ button:disabled {
   gap: 1.25rem;
 }
 
-.repo-card {
-  padding: 1.35rem 1.4rem;
-  border-radius: 18px;
-  border: 1px solid rgba(100, 116, 139, 0.2);
-  background: rgba(15, 23, 42, 0.68);
-  transition: border 0.2s ease, transform 0.2s ease;
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-}
-
-.repo-card:hover {
-  border-color: rgba(129, 140, 248, 0.35);
-  transform: translateY(-1px);
-}
-
-.repo-card.active {
-  border-color: rgba(59, 130, 246, 0.6);
-}
-
-.repo-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 1rem;
-}
-
-.repo-actions {
-  display: flex;
-  gap: 0.6rem;
-}
-
-.repo-name {
-  font-size: 1.05rem;
-  font-weight: 600;
-}
-
-.repo-branch {
-  margin-left: 0.75rem;
-  font-size: 0.8rem;
-  border-radius: 999px;
-  padding: 0.25rem 0.75rem;
-  background: rgba(236, 72, 153, 0.16);
-  border: 1px solid rgba(236, 72, 153, 0.28);
-  color: #fbcfe8;
-}
-
-.repo-meta {
-  margin-top: 1rem;
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 0.75rem;
-}
-
-.meta-pill {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-  padding: 0.75rem 0.9rem;
-  border-radius: 14px;
-  background: rgba(30, 41, 59, 0.66);
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  font-size: 0.85rem;
-  color: rgba(226, 232, 240, 0.9);
-}
-
-.meta-pill .label {
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: rgba(148, 163, 184, 0.75);
-}
-
-.repo-commit {
-  margin-top: 1rem;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-  align-items: center;
-}
-
-.commit-hash {
-  font-family: 'JetBrains Mono', 'SFMono-Regular', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-  background: rgba(129, 140, 248, 0.18);
-  border: 1px solid rgba(129, 140, 248, 0.4);
-  border-radius: 10px;
-  padding: 0.35rem 0.65rem;
-  font-size: 0.85rem;
-  letter-spacing: 0.05em;
-  color: #ede9fe;
-}
-
-.commit-title {
-  font-size: 0.9rem;
-  color: rgba(226, 232, 240, 0.9);
-}
-
-.commit-title.muted {
-  color: rgba(148, 163, 184, 0.65);
-}
-
-.repo-footer {
-  margin-top: 1.25rem;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem 1.5rem;
-  font-size: 0.85rem;
-  color: rgba(148, 163, 184, 0.85);
-}
-
-.repo-footer strong {
-  color: rgba(226, 232, 240, 0.9);
-  margin-right: 0.45rem;
-}
-
 .toast {
   position: fixed;
   bottom: 24px;
@@ -480,14 +449,14 @@ button:disabled {
   padding: 0.85rem 1.2rem;
   border-radius: 14px;
   background: rgba(248, 113, 113, 0.12);
-  border: 1px solid rgba(248, 113, 113, 0.35);
+  border: 1px solid var(--color-danger-border);
   color: #fecaca;
-  box-shadow: 0 18px 45px -25px rgba(248, 113, 113, 0.55);
+  box-shadow: var(--shadow-danger);
 }
 
 .toast-enter-active,
 .toast-leave-active {
-  transition: opacity 0.2s ease, transform 0.2s ease;
+  transition: opacity var(--transition-base), transform var(--transition-base);
 }
 
 .toast-enter-from,
@@ -500,6 +469,5 @@ button:disabled {
   .topbar {
     flex-direction: column;
     align-items: flex-start;
-    gap: 1rem;
   }
 }

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1,0 +1,88 @@
+export interface Credential {
+  id: number;
+  name: string;
+  type: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface AllocationStatus {
+  id: string;
+  name?: string;
+  client?: string;
+  status?: string;
+  desired?: string;
+  group?: string;
+  healthy?: boolean | null;
+}
+
+export interface RepoJob {
+  path: string;
+  job_id?: string;
+  job_name?: string;
+  namespace?: string;
+  job_type?: string;
+  last_commit?: string | null;
+  updated_at: string;
+  status?: string;
+  status_description?: string;
+  status_error?: string;
+  nomad_status?: string;
+  desired_allocations?: number;
+  running_allocations?: number;
+  starting_allocations?: number;
+  queued_allocations?: number;
+  failed_allocations?: number;
+  lost_allocations?: number;
+  unknown_allocations?: number;
+  latest_deployment_id?: string;
+  latest_allocation_id?: string;
+  latest_allocation_name?: string;
+  job_url?: string;
+  allocations?: AllocationStatus[];
+}
+
+export interface Repo {
+  id: number;
+  name: string;
+  repo_url: string;
+  branch: string;
+  job_path: string;
+  credential_id?: number | null;
+  last_commit?: string | null;
+  last_commit_author?: string | null;
+  last_commit_title?: string | null;
+  last_polled_at?: string | null;
+  jobs: RepoJob[];
+}
+
+export interface CompassStatus {
+  nomad_connected: boolean;
+  nomad_message?: string;
+}
+
+export interface CredentialPayload {
+  name: string;
+  type: string;
+  token?: string;
+  username?: string;
+  private_key?: string;
+  passphrase?: string;
+}
+
+export interface RepoPayload {
+  name: string;
+  repo_url: string;
+  branch: string;
+  job_path: string;
+  credential_id?: number;
+}
+
+export interface DeleteCredentialOptions {
+  deleteRepos: boolean;
+  unschedule: boolean;
+}
+
+export interface DeleteRepoOptions {
+  unschedule: boolean;
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,0 +1,1 @@
+export * from './api';

--- a/frontend/src/utils/__tests__/date.test.ts
+++ b/frontend/src/utils/__tests__/date.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { formatRelativeTime, formatTimestamp } from '@/utils/date';
+
+describe('formatRelativeTime', () => {
+  const now = new Date('2024-01-01T00:00:00Z');
+
+  it('returns human readable values for past timestamps', () => {
+    expect(formatRelativeTime('2023-12-31T00:00:00Z', now)).toBe('1 day ago');
+  });
+
+  it('returns human readable values for future timestamps', () => {
+    expect(formatRelativeTime('2024-01-01T01:00:00Z', now)).toBe('in 1 hour');
+  });
+
+  it('falls back to awaiting copy when value is missing', () => {
+    expect(formatRelativeTime(undefined, now)).toBe('Awaiting first poll');
+  });
+
+  it('returns original value when timestamp is invalid', () => {
+    expect(formatRelativeTime('not-a-date', now)).toBe('not-a-date');
+  });
+});
+
+describe('formatTimestamp', () => {
+  it('returns awaiting copy when value is missing', () => {
+    expect(formatTimestamp(null)).toBe('Awaiting first poll');
+  });
+
+  it('returns the original value when the timestamp cannot be parsed', () => {
+    expect(formatTimestamp('not-a-date')).toBe('not-a-date');
+  });
+
+  it('formats valid timestamps using locale aware formatting', () => {
+    const result = formatTimestamp('2024-01-01T00:00:00Z');
+    expect(result).toContain('2024');
+  });
+});

--- a/frontend/src/utils/__tests__/repos.test.ts
+++ b/frontend/src/utils/__tests__/repos.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { buildCommitUrl, formatCommitHash } from '@/utils/repos';
+
+const baseRepo = {
+  id: 1,
+  name: 'demo',
+  repo_url: '',
+  branch: 'main',
+  job_path: '.nomad',
+  jobs: [],
+};
+
+describe('buildCommitUrl', () => {
+  it('returns null when commit is missing', () => {
+    expect(buildCommitUrl({ ...baseRepo, last_commit: null })).toBeNull();
+  });
+
+  it('builds URLs for HTTPS repositories', () => {
+    const url = buildCommitUrl({ ...baseRepo, repo_url: 'https://github.com/acme/demo', last_commit: 'abcdef1' });
+    expect(url).toBe('https://github.com/acme/demo/commit/abcdef1');
+  });
+
+  it('builds URLs for SSH repositories', () => {
+    const url = buildCommitUrl({ ...baseRepo, repo_url: 'git@github.com:acme/demo.git', last_commit: 'abcdef1' });
+    expect(url).toBe('https://github.com/acme/demo/commit/abcdef1');
+  });
+
+  it('handles ssh protocol URLs', () => {
+    const url = buildCommitUrl({ ...baseRepo, repo_url: 'ssh://git@example.com/acme/demo.git', last_commit: 'abcdef1' });
+    expect(url).toBe('https://example.com/acme/demo/commit/abcdef1');
+  });
+});
+
+describe('formatCommitHash', () => {
+  it('falls back to pending when hash is missing', () => {
+    expect(formatCommitHash(null)).toBe('pending');
+  });
+
+  it('trims hash to the provided length', () => {
+    expect(formatCommitHash('abcdef123456', 8)).toBe('abcdef12');
+  });
+});

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -1,0 +1,50 @@
+const RELATIVE_THRESHOLDS = [
+  { limit: 365 * 24 * 60 * 60 * 1000, unit: 'year' as const },
+  { limit: 30 * 24 * 60 * 60 * 1000, unit: 'month' as const },
+  { limit: 7 * 24 * 60 * 60 * 1000, unit: 'week' as const },
+  { limit: 24 * 60 * 60 * 1000, unit: 'day' as const },
+  { limit: 60 * 60 * 1000, unit: 'hour' as const },
+  { limit: 60 * 1000, unit: 'minute' as const },
+];
+
+export function formatTimestamp(value?: string | null) {
+  if (!value) {
+    return 'Awaiting first poll';
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return date.toLocaleString();
+}
+
+export function formatRelativeTime(value?: string | null, now: Date = new Date()) {
+  if (!value) {
+    return 'Awaiting first poll';
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  const diff = date.getTime() - now.getTime();
+  const absDiff = Math.abs(diff);
+
+  const formatter = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
+
+  for (const threshold of RELATIVE_THRESHOLDS) {
+    if (absDiff >= threshold.limit) {
+      const amount = Math.round(diff / threshold.limit);
+      return formatter.format(amount, threshold.unit);
+    }
+  }
+
+  const seconds = Math.round(diff / 1000);
+  if (Math.abs(seconds) < 1) {
+    return 'just now';
+  }
+  return formatter.format(seconds, 'second');
+}

--- a/frontend/src/utils/repos.ts
+++ b/frontend/src/utils/repos.ts
@@ -1,0 +1,46 @@
+import type { Repo } from '@/types';
+
+export function buildCommitUrl(repo: Pick<Repo, 'repo_url' | 'last_commit'>) {
+  if (!repo.last_commit) {
+    return null;
+  }
+
+  const rawUrl = (repo.repo_url || '').trim();
+  if (!rawUrl) {
+    return null;
+  }
+
+  const normalized = rawUrl.replace(/\.git$/i, '');
+
+  if (normalized.startsWith('http://') || normalized.startsWith('https://')) {
+    return `${normalized}/commit/${repo.last_commit}`;
+  }
+
+  if (normalized.startsWith('git@')) {
+    const match = normalized.match(/^git@([^:]+):(.+)$/);
+    if (match) {
+      const [, host, path] = match;
+      return `https://${host}/${path}/commit/${repo.last_commit}`;
+    }
+  }
+
+  if (normalized.startsWith('ssh://')) {
+    try {
+      const url = new URL(normalized);
+      const host = url.hostname;
+      const path = url.pathname.replace(/\.git$/i, '').replace(/^\/+/, '');
+      return `https://${host}/${path}/commit/${repo.last_commit}`;
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+}
+
+export function formatCommitHash(hash?: string | null, length = 7) {
+  if (!hash) {
+    return 'pending';
+  }
+  return hash.slice(0, length);
+}

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -11,9 +11,9 @@
 </template>
 
 <script setup lang="ts">
-import RepoList from '../components/RepoList.vue';
-import type { Repo } from '../composables/useCompassStore';
-import { useCompassStore } from '../composables/useCompassStore';
+import RepoList from '@/components/RepoList.vue';
+import type { Repo } from '@/types';
+import { useCompassStore } from '@/composables/useCompassStore';
 
 const {
   repos,

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -11,10 +11,10 @@
 
 <script setup lang="ts">
 import { ref } from 'vue';
-import CredentialForm from '../components/CredentialForm.vue';
-import CredentialList from '../components/CredentialList.vue';
-import type { Credential } from '../composables/useCompassStore';
-import { useCompassStore } from '../composables/useCompassStore';
+import CredentialForm from '@/components/CredentialForm.vue';
+import CredentialList from '@/components/CredentialList.vue';
+import type { Credential } from '@/types';
+import { useCompassStore } from '@/composables/useCompassStore';
 
 const formRef = ref<InstanceType<typeof CredentialForm> | null>(null);
 

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -9,8 +9,12 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "esModuleInterop": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
     "lib": ["ESNext", "DOM"],
-    "types": ["vite/client"]
+    "types": ["vite/client", "vitest/globals"]
   },
   "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue"],
   "exclude": ["node_modules"]

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,13 +3,23 @@ import vue from '@vitejs/plugin-vue';
 
 export default defineConfig({
   plugins: [vue()],
+  resolve: {
+    alias: {
+      '@': new URL('./src', import.meta.url).pathname,
+    },
+  },
   build: {
     outDir: '../internal/web/dist',
     emptyOutDir: true,
   },
   server: {
     proxy: {
-      '/api': 'http://localhost:8080'
-    }
-  }
+      '/api': 'http://localhost:8080',
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './vitest.setup.ts',
+  },
 });

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,0 +1,1 @@
+// Shared test setup for Vitest. Extend this file as the test surface grows.


### PR DESCRIPTION
## Summary
- centralize API typing and request helpers so the compass store no longer owns fetch plumbing
- add shared date and repository formatting utilities with accompanying tests
- introduce reusable body scroll lock handling and global design tokens to simplify theming adjustments

## Testing
- npm run build
- npm test *(fails: vitest binary unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eb98991dd0832a8505c9a3e0fa53bc