### PR TITLE
Add Nomad workload identity support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ Nomad Compass is configured via environment variables:
 | `COMPASS_HTTP_ADDR` | HTTP listener address | `:8080` |
 | `COMPASS_DATABASE_PATH` | Path to SQLite database | `data/nomad-compass.sqlite` |
 | `COMPASS_NOMAD_ADDR` | Nomad API address | `http://127.0.0.1:4646` |
-| `COMPASS_NOMAD_TOKEN` | Nomad ACL token | _empty_ |
+| `COMPASS_NOMAD_TOKEN` | Explicit Nomad ACL token override (primarily for local/backward-compatible use) | falls back to `NOMAD_TOKEN` |
+| `NOMAD_TOKEN` | Nomad ACL token; automatically populated for tasks using Nomad Workload Identity with `identity { env = true }` | _empty_ |
 | `COMPASS_NOMAD_REGION` | Nomad region override | _empty_ |
 | `COMPASS_NOMAD_NAMESPACE` | Nomad namespace override | _empty_ |
 | `COMPASS_REPO_BASE_DIR` | Directory for cloned repositories | `data/repos` |
@@ -100,8 +101,7 @@ Run it in Nomad
 
 ```bash
 nomad run \
-  -var="nomad_token=token-goes-here" \
-  -var="credential_key=credential-key-goes-here" \
+  -var="credential_key=$(openssl rand -hex 32)" \
   example/nomad-compass.nomad.hcl
 ```
 

--- a/example/nomad-compass.nomad.hcl
+++ b/example/nomad-compass.nomad.hcl
@@ -18,11 +18,6 @@ variable "nomad_addr" {
   default = "http://host.docker.internal:4646"
 }
 
-variable "nomad_token" {
-  type    = string
-  default = "<your_nomad_token_here>"
-}
-
 variable "credential_key" {
   type    = string
   default = "<replace_with_your_credential_key>"
@@ -60,6 +55,10 @@ job "compass" {
     task "app" {
       driver = "docker"
 
+      identity {
+        env = true
+      }
+
       config {
         image = var.image
         ports = ["http"]
@@ -70,9 +69,9 @@ job "compass" {
         COMPASS_DATABASE_PATH = "/data/nomad-compass.sqlite"
         COMPASS_REPO_BASE_DIR = "/data/repos"
         # For local testing make sure the Nomad address is resolvable from within your container.
-        # Ideally replace the below three environment variables with Nomad or Vault secrets.
+        # Keep the credential encryption key in Nomad Variables or another secrets backend in production.
+        # NOMAD_TOKEN is supplied by the task workload identity configured above.
         COMPASS_NOMAD_ADDR     = var.nomad_addr
-        COMPASS_NOMAD_TOKEN    = var.nomad_token
         COMPASS_CREDENTIAL_KEY = var.credential_key
       }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,7 +67,7 @@ func Load() (*Config, error) {
 
 	cfg.Nomad = NomadConfig{
 		Address:   getEnv("COMPASS_NOMAD_ADDR", defaultNomadAddress),
-		Token:     os.Getenv("COMPASS_NOMAD_TOKEN"),
+		Token:     getEnv("COMPASS_NOMAD_TOKEN", os.Getenv("NOMAD_TOKEN")),
 		Region:    getEnv("COMPASS_NOMAD_REGION", ""),
 		Namespace: getEnv("COMPASS_NOMAD_NAMESPACE", ""),
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -29,6 +29,8 @@ func TestDecodeHexKeyInvalidLength(t *testing.T) {
 
 func TestLoadDefaults(t *testing.T) {
 	t.Setenv("COMPASS_CREDENTIAL_KEY", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	t.Setenv("COMPASS_NOMAD_TOKEN", "")
+	t.Setenv("NOMAD_TOKEN", "")
 	cfg, err := Load()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -50,6 +52,48 @@ func TestLoadDefaults(t *testing.T) {
 	}
 	if len(cfg.Crypto.CredentialKey) != 32 {
 		t.Fatalf("expected 32 byte key, got %d", len(cfg.Crypto.CredentialKey))
+	}
+}
+
+func TestLoadNomadTokenExplicitOverride(t *testing.T) {
+	t.Setenv("COMPASS_CREDENTIAL_KEY", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	t.Setenv("COMPASS_NOMAD_TOKEN", "explicit-token")
+	t.Setenv("NOMAD_TOKEN", "workload-identity-token")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Nomad.Token != "explicit-token" {
+		t.Fatal("expected COMPASS_NOMAD_TOKEN to take precedence")
+	}
+}
+
+func TestLoadNomadTokenWorkloadIdentityFallback(t *testing.T) {
+	t.Setenv("COMPASS_CREDENTIAL_KEY", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	t.Setenv("COMPASS_NOMAD_TOKEN", "")
+	t.Setenv("NOMAD_TOKEN", "workload-identity-token")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Nomad.Token != "workload-identity-token" {
+		t.Fatal("expected NOMAD_TOKEN fallback")
+	}
+}
+
+func TestLoadNomadTokenEmpty(t *testing.T) {
+	t.Setenv("COMPASS_CREDENTIAL_KEY", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	t.Setenv("COMPASS_NOMAD_TOKEN", "")
+	t.Setenv("NOMAD_TOKEN", "")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Nomad.Token != "" {
+		t.Fatal("expected an empty Nomad token")
 	}
 }
 


### PR DESCRIPTION
Update the configuration to support the standard `NOMAD_TOKEN` variable vended by Nomad workload identity.