### PR TITLE
Add bundle validation and reconciliation CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,42 @@ Nomad Compass is configured via environment variables:
 
 > ⚠️ The encryption key is mandatory. Generate one with `openssl rand -hex 32`.
 
+### Command-line validation
+
+The binary also exposes a side-effect-free bundle validation command. It parses the manifest, checks dependency ordering, validates supported native Nomad resource bodies, and prints stable spec and manifest hashes. It does not require `COMPASS_CREDENTIAL_KEY`, a database, or a live Nomad cluster:
+
+```bash
+go run ./cmd/nomad-compass bundle validate --file example/homelab-compass.bundle.hcl
+cat example/homelab-compass.bundle.hcl | go run ./cmd/nomad-compass bundle validate --file -
+go run ./cmd/nomad-compass --format json bundle validate --file example/homelab-compass.bundle.hcl
+```
+
+To compare two manifests and get a compact change summary, use the offline bundle plan command:
+
+```bash
+go run ./cmd/nomad-compass bundle plan \
+  --file desired.bundle.hcl \
+  --against previous.bundle.hcl \
+  --revision a1b2c3d
+```
+
+It emits a readable summary with one resource transition per line and a counted plan section. This is a manifest-to-manifest plan; it does not contact Nomad yet.
+
+When the Compass daemon is running, the CLI also exposes the HTTP API operations:
+
+```bash
+nomad-compass --format json --server http://127.0.0.1:8080 status
+nomad-compass repo list
+nomad-compass repo add --name homelab --url https://github.com/example/homelab.git --branch main
+nomad-compass repo reconcile --id 1
+nomad-compass repo delete --id 1 --unschedule --yes
+nomad-compass credential list
+nomad-compass credential add --name github --type https-token --token "$GITHUB_TOKEN"
+nomad-compass credential delete --id 1 --yes
+```
+
+Destructive commands require `--yes`; `--unschedule` explicitly requests Nomad resource removal. Global options such as `--format` and `--server` are placed before the command verbs.
+
 ### Running locally
 
 1. Install backend dependencies and prepare the database:

--- a/cmd/nomad-compass/main.go
+++ b/cmd/nomad-compass/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/brianmichel/nomad-compass/internal/auth"
+	"github.com/brianmichel/nomad-compass/internal/cli"
 	"github.com/brianmichel/nomad-compass/internal/config"
 	"github.com/brianmichel/nomad-compass/internal/nomadclient"
 	"github.com/brianmichel/nomad-compass/internal/reconcile"
@@ -19,6 +21,14 @@ import (
 )
 
 func main() {
+	if len(os.Args) > 1 {
+		if err := cli.Run(context.Background(), os.Args[1:], os.Stdin, os.Stdout, os.Stderr); err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, err)
+			os.Exit(2)
+		}
+		return
+	}
+
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/hashicorp/nomad v1.10.5
 	github.com/hashicorp/nomad/api v0.0.0-20251006133510-26485c45a2fb
 	github.com/mitchellh/mapstructure v1.5.0
+	github.com/spf13/cobra v1.9.1
 	golang.org/x/crypto v0.42.0
 	modernc.org/sqlite v1.39.0
 )
@@ -40,6 +41,7 @@ require (
 	github.com/hashicorp/go-cty-funcs v0.0.0-20200930094925-2721b1e36840 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
@@ -51,6 +53,7 @@ require (
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
 	github.com/skeema/knownhosts v1.3.1 // indirect
+	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/zclconf/go-cty v1.16.4 // indirect
 	github.com/zclconf/go-cty-yaml v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,7 @@ github.com/bmatcuk/doublestar v1.1.5 h1:2bNwBOmhyFEFcoB3tGvTD5xanq+4kyOZlB8wFYbM
 github.com/bmatcuk/doublestar v1.1.5/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
 github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
 github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
 github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -84,6 +85,8 @@ github.com/hashicorp/nomad v1.10.5 h1:KGQK0Ao9L7xtO/ZagS7tXD8MvFTr5R6y7SiOGhEXzW
 github.com/hashicorp/nomad v1.10.5/go.mod h1:NElc7qdOlCrkoKaJ8jyMo4+oX1U8TIxd8NM1TKtgVYE=
 github.com/hashicorp/nomad/api v0.0.0-20251006133510-26485c45a2fb h1:QdEQr0Vq3yU4dU/zN1lVZMHEgGsHPgFRP+tAGz0B6wU=
 github.com/hashicorp/nomad/api v0.0.0-20251006133510-26485c45a2fb/go.mod h1:sldFTIgs+FsUeKU3LwVjviAIuksxD8TzDOn02MYwslE=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
@@ -120,6 +123,7 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/shoenig/test v1.12.2 h1:ZVT8NeIUwGWpZcKaepPmFMoNQ3sVpxvqUh/MAqwFiJI=
@@ -127,6 +131,10 @@ github.com/shoenig/test v1.12.2/go.mod h1:UxJ6u/x2v/TNs/LoLxBNJRV9DiwBBKYxXSyczs
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=
+github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
+github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
+github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
+github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/internal/cli/api_test.go
+++ b/internal/cli/api_test.go
@@ -1,0 +1,97 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRunAPICommandsUseGlobalOptionsBeforeVerbs(t *testing.T) {
+	var requests []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.Method+" "+r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/status":
+			_ = json.NewEncoder(w).Encode(statusResponse{NomadConnected: true})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/repos":
+			_ = json.NewEncoder(w).Encode([]repositoryResponse{{ID: 7, Name: "homelab", Branch: "main", RepoURL: "https://example.test/repo"}})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/repos":
+			_ = json.NewEncoder(w).Encode(repositoryResponse{ID: 8, Name: "new-repo"})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/repos/8/reconcile":
+			w.WriteHeader(http.StatusAccepted)
+		case r.Method == http.MethodDelete && r.URL.Path == "/api/repos/8":
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	var statusOutput bytes.Buffer
+	if err := Run(context.Background(), []string{"--server", server.URL, "--format", "json", "status"}, nil, &statusOutput, nil); err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if !strings.Contains(statusOutput.String(), `"nomad_connected": true`) {
+		t.Fatalf("unexpected status output: %s", statusOutput.String())
+	}
+
+	var reposOutput bytes.Buffer
+	if err := Run(context.Background(), []string{"--server", server.URL, "repo", "list", "--format", "json"}, nil, &reposOutput, nil); err != nil {
+		t.Fatalf("repo list: %v", err)
+	}
+	if !strings.Contains(reposOutput.String(), `"name": "homelab"`) {
+		t.Fatalf("unexpected repo output: %s", reposOutput.String())
+	}
+
+	var addOutput bytes.Buffer
+	if err := Run(context.Background(), []string{"--server", server.URL, "repo", "add", "--name", "new-repo", "--url", "https://example.test/repo"}, nil, &addOutput, nil); err != nil {
+		t.Fatalf("repo add: %v", err)
+	}
+	if !strings.Contains(addOutput.String(), "repository 8 created") {
+		t.Fatalf("unexpected add output: %s", addOutput.String())
+	}
+
+	if err := Run(context.Background(), []string{"--server", server.URL, "repo", "reconcile", "--id", "8"}, nil, &bytes.Buffer{}, nil); err != nil {
+		t.Fatalf("repo reconcile: %v", err)
+	}
+	if err := Run(context.Background(), []string{"--server", server.URL, "repo", "delete", "--id", "8", "--yes"}, nil, &bytes.Buffer{}, nil); err != nil {
+		t.Fatalf("repo delete: %v", err)
+	}
+
+	want := []string{
+		"GET /api/status",
+		"GET /api/repos",
+		"POST /api/repos",
+		"POST /api/repos/8/reconcile",
+		"DELETE /api/repos/8",
+	}
+	if len(requests) != len(want) {
+		t.Fatalf("requests = %#v, want %#v", requests, want)
+	}
+	for i := range want {
+		if requests[i] != want[i] {
+			t.Errorf("request %d = %q, want %q", i, requests[i], want[i])
+		}
+	}
+}
+
+func TestRunDestructiveCommandsRequireConfirmation(t *testing.T) {
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+	defer server.Close()
+
+	err := Run(context.Background(), []string{"--server", server.URL, "repo", "delete", "--id", "8"}, nil, &bytes.Buffer{}, nil)
+	if err == nil || !strings.Contains(err.Error(), "requires --yes") {
+		t.Fatalf("expected confirmation error, got %v", err)
+	}
+	if called {
+		t.Fatal("confirmation failure made an API request")
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,0 +1,746 @@
+// Package cli implements Compass's command-line interface.
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/hashicorp/nomad/jobspec2"
+	"github.com/spf13/cobra"
+
+	"github.com/brianmichel/nomad-compass/internal/manifest"
+)
+
+// Run executes a Compass CLI command. It returns an error suitable for
+// presentation by the process entrypoint; it does not call os.Exit.
+func Run(ctx context.Context, args []string, in io.Reader, out, errOut io.Writer) error {
+	command := NewCommand(ctx, in, out, errOut)
+	command.SetArgs(args)
+	return command.ExecuteContext(ctx)
+}
+
+// NewCommand constructs the CLI root command. Keeping construction separate
+// from process execution makes command behavior easy to test and reuse.
+func NewCommand(ctx context.Context, in io.Reader, out, errOut io.Writer) *cobra.Command {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if in == nil {
+		in = strings.NewReader("")
+	}
+	if out == nil {
+		out = io.Discard
+	}
+	if errOut == nil {
+		errOut = io.Discard
+	}
+
+	state := &commandState{
+		in:     in,
+		out:    out,
+		errOut: errOut,
+		format: "text",
+		server: defaultServerURL(),
+	}
+	root := &cobra.Command{
+		Use:           "nomad-compass",
+		Short:         "GitOps operations for Nomad Compass",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
+	}
+	root.SetOut(out)
+	root.SetErr(errOut)
+	root.PersistentFlags().StringVar(&state.format, "format", state.format, "output format: text or json")
+	root.PersistentFlags().StringVar(&state.server, "server", state.server, "Compass HTTP API URL")
+	root.PersistentPreRunE = func(*cobra.Command, []string) error {
+		if state.format != "text" && state.format != "json" {
+			return fmt.Errorf("unsupported output format %q", state.format)
+		}
+		return nil
+	}
+
+	root.AddCommand(newBundleCommand(state))
+	root.AddCommand(newStatusCommand(state))
+	root.AddCommand(newRepoCommand(state))
+	root.AddCommand(newCredentialCommand(state))
+	return root
+}
+
+type commandState struct {
+	in     io.Reader
+	out    io.Writer
+	errOut io.Writer
+	format string
+	server string
+}
+
+func newBundleCommand(state *commandState) *cobra.Command {
+	bundle := &cobra.Command{
+		Use:   "bundle",
+		Short: "Validate and inspect Compass bundles",
+	}
+	validate := &cobra.Command{
+		Use:   "validate",
+		Short: "Validate a bundle without contacting Nomad",
+		Args:  cobra.NoArgs,
+	}
+	var filePath string
+	validate.Flags().StringVar(&filePath, "file", "", "bundle manifest path, or - to read stdin")
+	validate.RunE = func(cmd *cobra.Command, _ []string) error {
+		if filePath == "" {
+			return errors.New("bundle manifest path is required (--file path)")
+		}
+		return runBundleValidate(cmd.Context(), state, filePath)
+	}
+
+	var planFile, againstFile, revision string
+	plan := &cobra.Command{
+		Use:   "plan",
+		Short: "Show an offline change plan for a bundle",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if planFile == "" {
+				return errors.New("bundle manifest path is required (--file path)")
+			}
+			if againstFile == "-" {
+				return errors.New("--against cannot read stdin; use a file path")
+			}
+			return runBundlePlan(cmd.Context(), state, planFile, againstFile, revision)
+		},
+	}
+	plan.Flags().StringVar(&planFile, "file", "", "desired bundle manifest path, or - to read stdin")
+	plan.Flags().StringVar(&againstFile, "against", "", "optional previous bundle manifest to compare against")
+	plan.Flags().StringVar(&revision, "revision", "working-tree", "revision label to display")
+
+	bundle.AddCommand(validate, plan)
+	return bundle
+}
+
+func newStatusCommand(state *commandState) *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show Compass and Nomad connectivity",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			var status statusResponse
+			if err := state.client().get(cmd.Context(), "/api/status", &status); err != nil {
+				return err
+			}
+			return writeValue(state.out, state.format, status, func() error {
+				connected := "no"
+				if status.NomadConnected {
+					connected = "yes"
+				}
+				_, err := fmt.Fprintf(state.out, "Nomad connected: %s\n", connected)
+				if status.NomadMessage != "" {
+					_, _ = fmt.Fprintf(state.out, "Nomad message: %s\n", status.NomadMessage)
+				}
+				return err
+			})
+		},
+	}
+}
+
+func newRepoCommand(state *commandState) *cobra.Command {
+	repoCommand := &cobra.Command{
+		Use:   "repo",
+		Short: "Manage Git repositories tracked by Compass",
+	}
+
+	list := &cobra.Command{
+		Use:   "list",
+		Short: "List tracked repositories",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			var repos []repositoryResponse
+			if err := state.client().get(cmd.Context(), "/api/repos", &repos); err != nil {
+				return err
+			}
+			return writeValue(state.out, state.format, repos, func() error {
+				w := tabwriter.NewWriter(state.out, 0, 4, 2, ' ', 0)
+				if _, err := fmt.Fprintln(w, "ID\tNAME\tBRANCH\tURL\tJOBS"); err != nil {
+					return err
+				}
+				for _, repo := range repos {
+					if _, err := fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%d\n", repo.ID, repo.Name, repo.Branch, repo.RepoURL, len(repo.Jobs)); err != nil {
+						return err
+					}
+				}
+				return w.Flush()
+			})
+		},
+	}
+
+	var name, repoURL, branch, jobPath string
+	var credentialID int64
+	add := &cobra.Command{
+		Use:   "add",
+		Short: "Add and initially reconcile a repository",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if strings.TrimSpace(name) == "" || strings.TrimSpace(repoURL) == "" {
+				return errors.New("--name and --url are required")
+			}
+			payload := createRepoRequest{Name: name, RepoURL: repoURL, Branch: branch, JobPath: jobPath, CredentialID: credentialID}
+			var repo repositoryResponse
+			if err := state.client().post(cmd.Context(), "/api/repos", payload, &repo); err != nil {
+				return err
+			}
+			return writeValue(state.out, state.format, repo, func() error {
+				_, err := fmt.Fprintf(state.out, "repository %d created: %s\n", repo.ID, repo.Name)
+				return err
+			})
+		},
+	}
+	add.Flags().StringVar(&name, "name", "", "repository display name")
+	add.Flags().StringVar(&repoURL, "url", "", "Git repository URL")
+	add.Flags().StringVar(&branch, "branch", "main", "Git branch")
+	add.Flags().StringVar(&jobPath, "job-path", ".nomad", "path in the repository containing jobs or a bundle")
+	add.Flags().Int64Var(&credentialID, "credential-id", 0, "credential ID to use for Git authentication")
+
+	var reconcileID int64
+	reconcileCommand := &cobra.Command{
+		Use:   "reconcile",
+		Short: "Trigger reconciliation for one repository",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if reconcileID <= 0 {
+				return errors.New("--id must be greater than zero")
+			}
+			path := "/api/repos/" + strconv.FormatInt(reconcileID, 10) + "/reconcile"
+			if err := state.client().post(cmd.Context(), path, nil, nil); err != nil {
+				return err
+			}
+			_, err := fmt.Fprintf(state.out, "reconciliation requested for repository %d\n", reconcileID)
+			return err
+		},
+	}
+	reconcileCommand.Flags().Int64Var(&reconcileID, "id", 0, "repository ID")
+
+	var deleteID int64
+	var unschedule, confirm bool
+	deleteCommand := &cobra.Command{
+		Use:   "delete",
+		Short: "Delete repository metadata",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if deleteID <= 0 {
+				return errors.New("--id must be greater than zero")
+			}
+			if !confirm {
+				return errors.New("repository deletion requires --yes")
+			}
+			path := "/api/repos/" + strconv.FormatInt(deleteID, 10)
+			if err := state.client().delete(cmd.Context(), path, deleteRepoRequest{Unschedule: unschedule}); err != nil {
+				return err
+			}
+			_, err := fmt.Fprintf(state.out, "repository %d deleted\n", deleteID)
+			return err
+		},
+	}
+	deleteCommand.Flags().Int64Var(&deleteID, "id", 0, "repository ID")
+	deleteCommand.Flags().BoolVar(&unschedule, "unschedule", false, "remove managed Nomad resources")
+	deleteCommand.Flags().BoolVar(&confirm, "yes", false, "confirm deletion")
+
+	repoCommand.AddCommand(list, add, reconcileCommand, deleteCommand)
+	return repoCommand
+}
+
+func newCredentialCommand(state *commandState) *cobra.Command {
+	credentialCommand := &cobra.Command{
+		Use:   "credential",
+		Short: "Manage encrypted Git credentials",
+	}
+	list := &cobra.Command{
+		Use:   "list",
+		Short: "List credentials without revealing secret data",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			var credentials []credentialResponse
+			if err := state.client().get(cmd.Context(), "/api/credentials", &credentials); err != nil {
+				return err
+			}
+			return writeValue(state.out, state.format, credentials, func() error {
+				w := tabwriter.NewWriter(state.out, 0, 4, 2, ' ', 0)
+				if _, err := fmt.Fprintln(w, "ID\tNAME\tTYPE"); err != nil {
+					return err
+				}
+				for _, credential := range credentials {
+					if _, err := fmt.Fprintf(w, "%d\t%s\t%s\n", credential.ID, credential.Name, credential.Type); err != nil {
+						return err
+					}
+				}
+				return w.Flush()
+			})
+		},
+	}
+
+	var name, credentialType, token, username, privateKey, passphrase string
+	add := &cobra.Command{
+		Use:   "add",
+		Short: "Create an encrypted Git credential",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if strings.TrimSpace(name) == "" || strings.TrimSpace(credentialType) == "" {
+				return errors.New("--name and --type are required")
+			}
+			payload := createCredentialRequest{Name: name, Type: credentialType, Token: token, Username: username, PrivateKey: privateKey, Passphrase: passphrase}
+			var credential credentialResponse
+			if err := state.client().post(cmd.Context(), "/api/credentials", payload, &credential); err != nil {
+				return err
+			}
+			return writeValue(state.out, state.format, credential, func() error {
+				_, err := fmt.Fprintf(state.out, "credential %d created: %s\n", credential.ID, credential.Name)
+				return err
+			})
+		},
+	}
+	add.Flags().StringVar(&name, "name", "", "credential display name")
+	add.Flags().StringVar(&credentialType, "type", "", "credential type: https-token or ssh-key")
+	add.Flags().StringVar(&token, "token", "", "HTTPS token")
+	add.Flags().StringVar(&username, "username", "", "HTTPS username")
+	add.Flags().StringVar(&privateKey, "private-key", "", "SSH private key")
+	add.Flags().StringVar(&passphrase, "passphrase", "", "SSH private-key passphrase")
+
+	var deleteID int64
+	var deleteRepos, unschedule, confirm bool
+	deleteCommand := &cobra.Command{
+		Use:   "delete",
+		Short: "Delete a credential",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if deleteID <= 0 {
+				return errors.New("--id must be greater than zero")
+			}
+			if !confirm {
+				return errors.New("credential deletion requires --yes")
+			}
+			path := "/api/credentials/" + strconv.FormatInt(deleteID, 10)
+			payload := deleteCredentialRequest{DeleteRepos: deleteRepos, Unschedule: unschedule}
+			if err := state.client().delete(cmd.Context(), path, payload); err != nil {
+				return err
+			}
+			_, err := fmt.Fprintf(state.out, "credential %d deleted\n", deleteID)
+			return err
+		},
+	}
+	deleteCommand.Flags().Int64Var(&deleteID, "id", 0, "credential ID")
+	deleteCommand.Flags().BoolVar(&deleteRepos, "delete-repos", false, "delete repositories using this credential")
+	deleteCommand.Flags().BoolVar(&unschedule, "unschedule", false, "remove managed Nomad resources")
+	deleteCommand.Flags().BoolVar(&confirm, "yes", false, "confirm deletion")
+
+	credentialCommand.AddCommand(list, add, deleteCommand)
+	return credentialCommand
+}
+
+func runBundleValidate(ctx context.Context, state *commandState, filePath string) error {
+	bundle, resources, err := loadValidatedBundle(ctx, state.in, filePath)
+	if err != nil {
+		return err
+	}
+	report := ValidationReport{Valid: true, Bundle: bundle.Name, Path: displayPath(filePath), Resources: resources}
+	return writeValue(state.out, state.format, report, func() error {
+		return writeTextReport(state.out, report)
+	})
+}
+
+func loadValidatedBundle(ctx context.Context, in io.Reader, filePath string) (*manifest.Bundle, []ResourceReport, error) {
+	source, err := readBundle(filePath, in)
+	if err != nil {
+		return nil, nil, err
+	}
+	bundle, err := manifest.Parse(source, displayPath(filePath))
+	if err != nil {
+		return nil, nil, err
+	}
+	ordered, err := bundle.OrderedResources()
+	if err != nil {
+		return nil, nil, err
+	}
+	resources, err := validateResources(ctx, ordered)
+	if err != nil {
+		return nil, nil, err
+	}
+	return bundle, resources, nil
+}
+
+// PlanReport is the stable machine-readable result of bundle plan.
+type PlanReport struct {
+	Bundle     string         `json:"bundle"`
+	Revision   string         `json:"revision"`
+	ComparedTo string         `json:"compared_to,omitempty"`
+	Resources  []PlanResource `json:"resources"`
+	Summary    PlanSummary    `json:"summary"`
+}
+
+// PlanResource describes one offline desired-state transition.
+type PlanResource struct {
+	Action       string `json:"action"`
+	Address      string `json:"address"`
+	Kind         string `json:"kind"`
+	DeleteMode   string `json:"delete_mode"`
+	SpecHash     string `json:"spec_hash,omitempty"`
+	ManifestHash string `json:"manifest_hash,omitempty"`
+}
+
+// PlanSummary counts the transitions in a plan.
+type PlanSummary struct {
+	Create    int `json:"create"`
+	Update    int `json:"update"`
+	Delete    int `json:"delete"`
+	Protected int `json:"protected"`
+	Unchanged int `json:"unchanged"`
+}
+
+// ValidationReport is the stable machine-readable result of bundle validate.
+type ValidationReport struct {
+	Valid     bool             `json:"valid"`
+	Bundle    string           `json:"bundle"`
+	Path      string           `json:"path"`
+	Resources []ResourceReport `json:"resources"`
+}
+
+// ResourceReport describes a validated resource in dependency order.
+type ResourceReport struct {
+	Address      string   `json:"address"`
+	Kind         string   `json:"kind"`
+	DeleteMode   string   `json:"delete_mode"`
+	DependsOn    []string `json:"depends_on,omitempty"`
+	SpecHash     string   `json:"spec_hash"`
+	ManifestHash string   `json:"manifest_hash"`
+}
+
+func validateResources(ctx context.Context, resources []manifest.Resource) ([]ResourceReport, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	reports := make([]ResourceReport, 0, len(resources))
+	for _, resource := range resources {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		switch resource.Kind {
+		case "job":
+			source, err := manifest.NativeJobSource(resource)
+			if err != nil {
+				return nil, err
+			}
+			if _, err := jobspec2.ParseWithConfig(&jobspec2.ParseConfig{Body: source, Path: resource.SourcePath, Strict: true}); err != nil {
+				return nil, fmt.Errorf("validate bundle job %q: %w", resource.Address, err)
+			}
+		case "volume":
+			if _, err := manifest.CompileVolume(resource); err != nil {
+				return nil, fmt.Errorf("validate bundle volume %q: %w", resource.Address, err)
+			}
+		case "acl_policy":
+			if _, err := manifest.CompileACLPolicy(resource); err != nil {
+				return nil, fmt.Errorf("validate bundle ACL policy %q: %w", resource.Address, err)
+			}
+		default:
+			return nil, fmt.Errorf("bundle resource %q uses kind %q, which the CLI cannot validate yet", resource.Address, resource.Kind)
+		}
+		reports = append(reports, ResourceReport{Address: resource.Address, Kind: resource.Kind, DeleteMode: string(resource.DeleteMode), DependsOn: append([]string(nil), resource.DependsOn...), SpecHash: manifest.SpecHash(resource), ManifestHash: manifest.ManifestHash(resource)})
+	}
+	return reports, nil
+}
+
+func writeTextReport(out io.Writer, report ValidationReport) error {
+	if _, err := fmt.Fprintf(out, "valid bundle %q (%s)\nresources:\n", report.Bundle, report.Path); err != nil {
+		return err
+	}
+	for index, resource := range report.Resources {
+		if _, err := fmt.Fprintf(out, "  %d. %s [%s] spec=%s manifest=%s\n", index+1, resource.Address, resource.DeleteMode, resource.SpecHash, resource.ManifestHash); err != nil {
+			return err
+		}
+		if len(resource.DependsOn) > 0 {
+			if _, err := fmt.Fprintf(out, "     depends_on: %s\n", strings.Join(resource.DependsOn, ", ")); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func runBundlePlan(ctx context.Context, state *commandState, desiredPath, againstPath, revision string) error {
+	desired, desiredResources, err := loadValidatedBundle(ctx, state.in, desiredPath)
+	if err != nil {
+		return err
+	}
+	var previous *manifest.Bundle
+	if againstPath != "" {
+		previous, _, err = loadValidatedBundle(ctx, nil, againstPath)
+		if err != nil {
+			return fmt.Errorf("load comparison bundle: %w", err)
+		}
+	}
+
+	desiredByAddress := make(map[string]manifest.Resource, len(desired.Resources))
+	for _, resource := range desired.Resources {
+		desiredByAddress[resource.Address] = resource
+	}
+	previousByAddress := make(map[string]manifest.Resource)
+	if previous != nil {
+		for _, resource := range previous.Resources {
+			previousByAddress[resource.Address] = resource
+		}
+	}
+
+	plan := PlanReport{Bundle: desired.Name, Revision: revision, ComparedTo: againstPath}
+	for _, report := range desiredResources {
+		resource := desiredByAddress[report.Address]
+		action := "create"
+		if old, exists := previousByAddress[resource.Address]; exists {
+			action = "unchanged"
+			if manifest.SpecHash(resource) != manifest.SpecHash(old) || manifest.ManifestHash(resource) != manifest.ManifestHash(old) {
+				action = "update"
+			}
+		}
+		plan.Resources = append(plan.Resources, PlanResource{Action: action, Address: resource.Address, Kind: resource.Kind, DeleteMode: string(resource.DeleteMode), SpecHash: report.SpecHash, ManifestHash: report.ManifestHash})
+		incrementPlanSummary(&plan.Summary, action)
+	}
+	if previous != nil {
+		previousOrdered, err := previous.OrderedResources()
+		if err != nil {
+			return err
+		}
+		for _, resource := range previousOrdered {
+			if _, exists := desiredByAddress[resource.Address]; exists {
+				continue
+			}
+			action := "delete"
+			if resource.DeleteMode == manifest.DeleteModeProtect {
+				action = "protected"
+			}
+			plan.Resources = append(plan.Resources, PlanResource{Action: action, Address: resource.Address, Kind: resource.Kind, DeleteMode: string(resource.DeleteMode), SpecHash: manifest.SpecHash(resource), ManifestHash: manifest.ManifestHash(resource)})
+			incrementPlanSummary(&plan.Summary, action)
+		}
+	}
+
+	return writeValue(state.out, state.format, plan, func() error {
+		return writeTextPlan(state.out, plan)
+	})
+}
+
+func incrementPlanSummary(summary *PlanSummary, action string) {
+	switch action {
+	case "create":
+		summary.Create++
+	case "update":
+		summary.Update++
+	case "delete":
+		summary.Delete++
+	case "protected":
+		summary.Protected++
+	case "unchanged":
+		summary.Unchanged++
+	}
+}
+
+func writeTextPlan(out io.Writer, plan PlanReport) error {
+	if _, err := fmt.Fprintf(out, "Bundle: %s\nRevision: %s\n\n", plan.Bundle, plan.Revision); err != nil {
+		return err
+	}
+	for _, resource := range plan.Resources {
+		symbol := map[string]string{"create": "+", "update": "~", "delete": "-", "protected": "!", "unchanged": "="}[resource.Action]
+		line := fmt.Sprintf("%s %s", symbol, resource.Address)
+		if resource.Action == "protected" {
+			line += " deletion protected"
+		}
+		if _, err := fmt.Fprintln(out, line); err != nil {
+			return err
+		}
+	}
+	if _, err := fmt.Fprintln(out, "\nPlan:"); err != nil {
+		return err
+	}
+	for _, item := range []struct {
+		count int
+		name  string
+	}{
+		{plan.Summary.Create, "create"},
+		{plan.Summary.Update, "update"},
+		{plan.Summary.Delete, "delete"},
+		{plan.Summary.Protected, "protected"},
+		{plan.Summary.Unchanged, "unchanged"},
+	} {
+		if _, err := fmt.Fprintf(out, "  %d %s\n", item.count, item.name); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeValue(out io.Writer, format string, value any, text func() error) error {
+	if format == "text" {
+		return text()
+	}
+	encoder := json.NewEncoder(out)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(value)
+}
+
+func readBundle(path string, in io.Reader) ([]byte, error) {
+	if path == "-" {
+		contents, err := io.ReadAll(in)
+		if err != nil {
+			return nil, fmt.Errorf("read bundle from stdin: %w", err)
+		}
+		return contents, nil
+	}
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read bundle %q: %w", path, err)
+	}
+	return contents, nil
+}
+
+func displayPath(path string) string {
+	if path == "-" {
+		return "<stdin>"
+	}
+	return path
+}
+
+func defaultServerURL() string {
+	address := os.Getenv("COMPASS_HTTP_ADDR")
+	if address == "" {
+		address = ":8080"
+	}
+	return normalizeServerURL(address)
+}
+
+func normalizeServerURL(address string) string {
+	address = strings.TrimSpace(address)
+	if strings.HasPrefix(address, ":") {
+		return "http://127.0.0.1" + address
+	}
+	if !strings.Contains(address, "://") {
+		return "http://" + address
+	}
+	return strings.TrimRight(address, "/")
+}
+
+type serverClient struct {
+	baseURL string
+	http    *http.Client
+}
+
+func (state *commandState) client() *serverClient {
+	return &serverClient{baseURL: normalizeServerURL(state.server), http: &http.Client{Timeout: 30 * time.Second}}
+}
+
+func (c *serverClient) get(ctx context.Context, path string, result any) error {
+	return c.request(ctx, http.MethodGet, path, nil, result)
+}
+
+func (c *serverClient) post(ctx context.Context, path string, payload, result any) error {
+	return c.request(ctx, http.MethodPost, path, payload, result)
+}
+
+func (c *serverClient) delete(ctx context.Context, path string, payload any) error {
+	return c.request(ctx, http.MethodDelete, path, payload, nil)
+}
+
+func (c *serverClient) request(ctx context.Context, method, path string, payload, result any) error {
+	var body io.Reader
+	if payload != nil {
+		encoded, err := json.Marshal(payload)
+		if err != nil {
+			return err
+		}
+		body = strings.NewReader(string(encoded))
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, body)
+	if err != nil {
+		return err
+	}
+	if payload != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("Compass API request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		var failure struct {
+			Error string `json:"error"`
+		}
+		if decodeErr := json.NewDecoder(resp.Body).Decode(&failure); decodeErr == nil && failure.Error != "" {
+			return fmt.Errorf("Compass API: %s", failure.Error)
+		}
+		return fmt.Errorf("Compass API returned HTTP %s", resp.Status)
+	}
+	if result == nil {
+		return nil
+	}
+	if err := json.NewDecoder(resp.Body).Decode(result); err != nil {
+		return fmt.Errorf("decode Compass API response: %w", err)
+	}
+	return nil
+}
+
+type statusResponse struct {
+	NomadConnected bool   `json:"nomad_connected"`
+	NomadMessage   string `json:"nomad_message,omitempty"`
+}
+
+type repositoryResponse struct {
+	ID         int64           `json:"id"`
+	Name       string          `json:"name"`
+	RepoURL    string          `json:"repo_url"`
+	Branch     string          `json:"branch"`
+	JobPath    string          `json:"job_path"`
+	Jobs       []repositoryJob `json:"jobs"`
+	LastCommit *string         `json:"last_commit,omitempty"`
+}
+
+type repositoryJob struct {
+	Path   string `json:"path"`
+	JobID  string `json:"job_id,omitempty"`
+	Status string `json:"status,omitempty"`
+}
+
+type credentialResponse struct {
+	ID   int64  `json:"id"`
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+type createRepoRequest struct {
+	Name         string `json:"name"`
+	RepoURL      string `json:"repo_url"`
+	Branch       string `json:"branch"`
+	JobPath      string `json:"job_path"`
+	CredentialID int64  `json:"credential_id"`
+}
+
+type deleteRepoRequest struct {
+	Unschedule bool `json:"unschedule"`
+}
+
+type createCredentialRequest struct {
+	Name       string `json:"name"`
+	Type       string `json:"type"`
+	Token      string `json:"token"`
+	Username   string `json:"username"`
+	PrivateKey string `json:"private_key"`
+	Passphrase string `json:"passphrase"`
+}
+
+type deleteCredentialRequest struct {
+	Unschedule  bool `json:"unschedule"`
+	DeleteRepos bool `json:"delete_repos"`
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -220,11 +220,14 @@ func newRepoCommand(state *commandState) *cobra.Command {
 				return errors.New("--id must be greater than zero")
 			}
 			path := "/api/repos/" + strconv.FormatInt(reconcileID, 10) + "/reconcile"
-			if err := state.client().post(cmd.Context(), path, nil, nil); err != nil {
+			var response map[string]string
+			if err := state.client().post(cmd.Context(), path, nil, &response); err != nil {
 				return err
 			}
-			_, err := fmt.Fprintf(state.out, "reconciliation requested for repository %d\n", reconcileID)
-			return err
+			return writeValue(state.out, state.format, response, func() error {
+				_, err := fmt.Fprintf(state.out, "reconciliation requested for repository %d\n", reconcileID)
+				return err
+			})
 		},
 	}
 	reconcileCommand.Flags().Int64Var(&reconcileID, "id", 0, "repository ID")
@@ -243,11 +246,14 @@ func newRepoCommand(state *commandState) *cobra.Command {
 				return errors.New("repository deletion requires --yes")
 			}
 			path := "/api/repos/" + strconv.FormatInt(deleteID, 10)
-			if err := state.client().delete(cmd.Context(), path, deleteRepoRequest{Unschedule: unschedule}); err != nil {
+			var response map[string]string
+			if err := state.client().delete(cmd.Context(), path, deleteRepoRequest{Unschedule: unschedule}, &response); err != nil {
 				return err
 			}
-			_, err := fmt.Fprintf(state.out, "repository %d deleted\n", deleteID)
-			return err
+			return writeValue(state.out, state.format, response, func() error {
+				_, err := fmt.Fprintf(state.out, "repository %d deleted\n", deleteID)
+				return err
+			})
 		},
 	}
 	deleteCommand.Flags().Int64Var(&deleteID, "id", 0, "repository ID")
@@ -296,6 +302,9 @@ func newCredentialCommand(state *commandState) *cobra.Command {
 			if strings.TrimSpace(name) == "" || strings.TrimSpace(credentialType) == "" {
 				return errors.New("--name and --type are required")
 			}
+			if err := validateCredentialInput(credentialType, token, privateKey); err != nil {
+				return err
+			}
 			payload := createCredentialRequest{Name: name, Type: credentialType, Token: token, Username: username, PrivateKey: privateKey, Passphrase: passphrase}
 			var credential credentialResponse
 			if err := state.client().post(cmd.Context(), "/api/credentials", payload, &credential); err != nil {
@@ -327,13 +336,19 @@ func newCredentialCommand(state *commandState) *cobra.Command {
 			if !confirm {
 				return errors.New("credential deletion requires --yes")
 			}
+			if unschedule && !deleteRepos {
+				return errors.New("--unschedule requires --delete-repos")
+			}
 			path := "/api/credentials/" + strconv.FormatInt(deleteID, 10)
 			payload := deleteCredentialRequest{DeleteRepos: deleteRepos, Unschedule: unschedule}
-			if err := state.client().delete(cmd.Context(), path, payload); err != nil {
+			var response map[string]string
+			if err := state.client().delete(cmd.Context(), path, payload, &response); err != nil {
 				return err
 			}
-			_, err := fmt.Fprintf(state.out, "credential %d deleted\n", deleteID)
-			return err
+			return writeValue(state.out, state.format, response, func() error {
+				_, err := fmt.Fprintf(state.out, "credential %d deleted\n", deleteID)
+				return err
+			})
 		},
 	}
 	deleteCommand.Flags().Int64Var(&deleteID, "id", 0, "credential ID")
@@ -649,8 +664,8 @@ func (c *serverClient) post(ctx context.Context, path string, payload, result an
 	return c.request(ctx, http.MethodPost, path, payload, result)
 }
 
-func (c *serverClient) delete(ctx context.Context, path string, payload any) error {
-	return c.request(ctx, http.MethodDelete, path, payload, nil)
+func (c *serverClient) delete(ctx context.Context, path string, payload, result any) error {
+	return c.request(ctx, http.MethodDelete, path, payload, result)
 }
 
 func (c *serverClient) request(ctx context.Context, method, path string, payload, result any) error {
@@ -686,7 +701,7 @@ func (c *serverClient) request(ctx context.Context, method, path string, payload
 	if result == nil {
 		return nil
 	}
-	if err := json.NewDecoder(resp.Body).Decode(result); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(result); err != nil && !errors.Is(err, io.EOF) {
 		return fmt.Errorf("decode Compass API response: %w", err)
 	}
 	return nil
@@ -714,9 +729,11 @@ type repositoryJob struct {
 }
 
 type credentialResponse struct {
-	ID   int64  `json:"id"`
-	Name string `json:"name"`
-	Type string `json:"type"`
+	ID        int64     `json:"id"`
+	Name      string    `json:"name"`
+	Type      string    `json:"type"`
+	CreatedAt time.Time `json:"created_at,omitempty"`
+	UpdatedAt time.Time `json:"updated_at,omitempty"`
 }
 
 type createRepoRequest struct {
@@ -743,4 +760,20 @@ type createCredentialRequest struct {
 type deleteCredentialRequest struct {
 	Unschedule  bool `json:"unschedule"`
 	DeleteRepos bool `json:"delete_repos"`
+}
+
+func validateCredentialInput(credentialType, token, privateKey string) error {
+	switch credentialType {
+	case "https-token":
+		if strings.TrimSpace(token) == "" {
+			return errors.New("--token is required for https-token credentials")
+		}
+	case "ssh-key":
+		if strings.TrimSpace(privateKey) == "" {
+			return errors.New("--private-key is required for ssh-key credentials")
+		}
+	default:
+		return fmt.Errorf("unsupported credential type %q", credentialType)
+	}
+	return nil
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,0 +1,91 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunBundleValidateJSONReportsDependencyOrderAndHashes(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "compass.bundle.hcl")
+	contents := []byte(`bundle "example" {
+  resource "volume" "data" {
+    name = "example-data"
+    type = "host"
+  }
+
+  resource "job" "app" {
+    depends_on = ["volume.data"]
+    datacenters = ["dc1"]
+    group "app" {
+      task "server" {
+        driver = "docker"
+      }
+    }
+  }
+}`)
+	if err := os.WriteFile(path, contents, 0o600); err != nil {
+		t.Fatalf("write bundle: %v", err)
+	}
+
+	var output bytes.Buffer
+	if err := Run(context.Background(), []string{"bundle", "validate", "--file", path, "--format", "json"}, nil, &output, nil); err != nil {
+		t.Fatalf("validate bundle: %v", err)
+	}
+
+	var report ValidationReport
+	if err := json.Unmarshal(output.Bytes(), &report); err != nil {
+		t.Fatalf("decode report: %v\n%s", err, output.String())
+	}
+	if !report.Valid || report.Bundle != "example" || len(report.Resources) != 2 {
+		t.Fatalf("unexpected report: %#v", report)
+	}
+	if report.Resources[0].Address != "volume.data" || report.Resources[1].Address != "job.app" {
+		t.Fatalf("resources are not in dependency order: %#v", report.Resources)
+	}
+	if report.Resources[1].ManifestHash == "" || report.Resources[1].SpecHash == "" {
+		t.Fatalf("expected hashes in report: %#v", report.Resources[1])
+	}
+	if len(report.Resources[1].DependsOn) != 1 || report.Resources[1].DependsOn[0] != "volume.data" {
+		t.Fatalf("unexpected dependencies: %#v", report.Resources[1].DependsOn)
+	}
+}
+
+func TestRunBundleValidateReadsStdinAndWritesText(t *testing.T) {
+	input := strings.NewReader(`bundle "stdin" {
+  resource "acl_policy" "read" {
+    rules {
+      namespace "default" {
+        policy = "read"
+      }
+    }
+  }
+}`)
+	var output bytes.Buffer
+	if err := Run(context.Background(), []string{"bundle", "validate", "--file", "-"}, input, &output, nil); err != nil {
+		t.Fatalf("validate stdin bundle: %v", err)
+	}
+	if !strings.Contains(output.String(), `valid bundle "stdin" (<stdin>)`) || !strings.Contains(output.String(), "acl_policy.read") {
+		t.Fatalf("unexpected text report: %s", output.String())
+	}
+}
+
+func TestRunBundleValidateRejectsInvalidResource(t *testing.T) {
+	input := strings.NewReader(`bundle "invalid" {
+  resource "acl_policy" "missing-rules" {
+    description = "invalid"
+  }
+}`)
+	var output bytes.Buffer
+	err := Run(context.Background(), []string{"bundle", "validate", "--file", "-"}, input, &output, nil)
+	if err == nil || !strings.Contains(err.Error(), "must contain a rules block") {
+		t.Fatalf("expected validation error, got %v", err)
+	}
+	if output.Len() != 0 {
+		t.Fatalf("expected no success output for invalid bundle: %s", output.String())
+	}
+}

--- a/internal/cli/plan_test.go
+++ b/internal/cli/plan_test.go
@@ -1,0 +1,88 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunBundlePlanProducesCompactHumanSummary(t *testing.T) {
+	dir := t.TempDir()
+	previousPath := filepath.Join(dir, "previous.bundle.hcl")
+	desiredPath := filepath.Join(dir, "desired.bundle.hcl")
+	previous := []byte(`bundle "apps" {
+  resource "volume" "data" {
+    name = "data"
+    type = "host"
+  }
+  resource "volume" "legacy" {
+    name = "legacy"
+    type = "host"
+  }
+  resource "acl_policy" "web" {
+    rules {
+      namespace "default" { policy = "read" }
+    }
+  }
+  resource "job" "legacy" {
+    datacenters = ["dc1"]
+    group "legacy" {
+      task "legacy" {
+        driver = "docker"
+      }
+    }
+  }
+}`)
+	desired := []byte(`bundle "apps" {
+  resource "volume" "data" {
+    name = "data"
+    type = "host"
+  }
+  resource "acl_policy" "web" {
+    description = "updated"
+    rules {
+      namespace "default" { policy = "write" }
+    }
+  }
+  resource "job" "worker" {
+    datacenters = ["dc1"]
+    group "worker" {
+      task "worker" {
+        driver = "docker"
+      }
+    }
+  }
+}`)
+	if err := os.WriteFile(previousPath, previous, 0o600); err != nil {
+		t.Fatalf("write previous bundle: %v", err)
+	}
+	if err := os.WriteFile(desiredPath, desired, 0o600); err != nil {
+		t.Fatalf("write desired bundle: %v", err)
+	}
+
+	var output bytes.Buffer
+	err := Run(context.Background(), []string{
+		"bundle", "plan", "--file", desiredPath, "--against", previousPath,
+		"--revision", "a1b2c3d",
+	}, nil, &output, nil)
+	if err != nil {
+		t.Fatalf("plan bundle: %v", err)
+	}
+	text := output.String()
+	for _, expected := range []string{
+		"Bundle: apps\nRevision: a1b2c3d",
+		"+ job.worker",
+		"~ acl_policy.web",
+		"= volume.data",
+		"- job.legacy",
+		"! volume.legacy deletion protected",
+		"Plan:\n  1 create\n  1 update\n  1 delete\n  1 protected\n  1 unchanged",
+	} {
+		if !strings.Contains(text, expected) {
+			t.Errorf("plan output missing %q:\n%s", expected, text)
+		}
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -204,10 +204,11 @@ func (s *Server) handleCreateCredential(w http.ResponseWriter, r *http.Request) 
 	}
 
 	payload := storage.CredentialPayload{
-		Token:      req.Token,
-		Username:   req.Username,
-		PrivateKey: req.PrivateKey,
-		Passphrase: req.Passphrase,
+		Token: req.Token, Username: req.Username, PrivateKey: req.PrivateKey, Passphrase: req.Passphrase,
+	}
+	if err := storage.ValidateCredential(storage.CredentialType(req.Type), payload); err != nil {
+		respondStatus(w, http.StatusBadRequest, err)
+		return
 	}
 
 	cred, err := s.creds.Create(r.Context(), req.Name, storage.CredentialType(req.Type), payload)

--- a/internal/storage/credentials.go
+++ b/internal/storage/credentials.go
@@ -29,8 +29,28 @@ func NewCredentialStore(db *sql.DB, encryptor *auth.Encryptor) *CredentialStore 
 	return &CredentialStore{db: db, encryptor: encryptor}
 }
 
+// ValidateCredential checks the type-specific fields before persistence.
+func ValidateCredential(ctype CredentialType, payload CredentialPayload) error {
+	switch ctype {
+	case CredentialTypeHTTPToken:
+		if payload.Token == "" {
+			return errors.New("HTTPS token is required")
+		}
+	case CredentialTypeSSHKey:
+		if payload.PrivateKey == "" {
+			return errors.New("SSH private key is required")
+		}
+	default:
+		return fmt.Errorf("unsupported credential type: %s", ctype)
+	}
+	return nil
+}
+
 // Create stores a new credential entry.
 func (s *CredentialStore) Create(ctx context.Context, name string, ctype CredentialType, payload CredentialPayload) (*Credential, error) {
+	if err := ValidateCredential(ctype, payload); err != nil {
+		return nil, err
+	}
 	raw, err := json.Marshal(payload)
 	if err != nil {
 		return nil, fmt.Errorf("marshal payload: %w", err)


### PR DESCRIPTION
## Summary
Adds the CLI command surface for validating bundles and invoking reconciliation workflows.

## Review focus
- CLI/API boundaries
- Error handling and command output
- Backward compatibility with legacy repositories

## Stack
Builds on #18.

## Validation
`go test ./...`