### PR TITLE
Add shared live and offline planning

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -10,6 +10,10 @@ node = "20"
 [tasks.go-test]
 run = "go test ./... -v"
 
+[tasks.coverage]
+description = "Run Go tests and print package and total coverage"
+run = "mkdir -p .tmp && go test ./... -coverprofile=.tmp/coverage.out && go tool cover -func=.tmp/coverage.out | tail -1"
+
 [tasks.frontend-install]
 dir = "frontend"
 run = "npm install"

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ When the Compass daemon is running, the CLI also exposes the HTTP API operations
 nomad-compass --format json --server http://127.0.0.1:8080 status
 nomad-compass repo list
 nomad-compass repo add --name homelab --url https://github.com/example/homelab.git --branch main
+nomad-compass repo plan --id 1
 nomad-compass repo reconcile --id 1
 nomad-compass repo delete --id 1 --unschedule --yes
 nomad-compass credential list
@@ -90,7 +91,7 @@ nomad-compass credential add --name github --type https-token --token "$GITHUB_T
 nomad-compass credential delete --id 1 --yes
 ```
 
-Destructive commands require `--yes`; `--unschedule` explicitly requests Nomad resource removal. Global options such as `--format` and `--server` are placed before the command verbs.
+`repo plan` is read-only: it syncs the repository, observes tracked resources in Nomad, and reports create/update/delete/protected/unchanged actions without mutating Compass state or Nomad. Destructive commands require `--yes`; `--unschedule` explicitly requests Nomad resource removal. Global options such as `--format` and `--server` are placed before the command verbs.
 
 ### Running locally
 

--- a/internal/cli/api_test.go
+++ b/internal/cli/api_test.go
@@ -24,6 +24,8 @@ func TestRunAPICommandsUseGlobalOptionsBeforeVerbs(t *testing.T) {
 			_ = json.NewEncoder(w).Encode(repositoryResponse{ID: 8, Name: "new-repo"})
 		case r.Method == http.MethodPost && r.URL.Path == "/api/repos/8/reconcile":
 			w.WriteHeader(http.StatusAccepted)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/repos/8/plan":
+			_ = json.NewEncoder(w).Encode(PlanReport{Bundle: "apps", Revision: "a1b2c3d", Summary: PlanSummary{Unchanged: 1}})
 		case r.Method == http.MethodDelete && r.URL.Path == "/api/repos/8":
 			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 		default:
@@ -59,6 +61,13 @@ func TestRunAPICommandsUseGlobalOptionsBeforeVerbs(t *testing.T) {
 	if err := Run(context.Background(), []string{"--server", server.URL, "repo", "reconcile", "--id", "8"}, nil, &bytes.Buffer{}, nil); err != nil {
 		t.Fatalf("repo reconcile: %v", err)
 	}
+	var planOutput bytes.Buffer
+	if err := Run(context.Background(), []string{"--server", server.URL, "--format", "json", "repo", "plan", "--id", "8"}, nil, &planOutput, nil); err != nil {
+		t.Fatalf("repo plan: %v", err)
+	}
+	if !strings.Contains(planOutput.String(), `"revision": "a1b2c3d"`) {
+		t.Fatalf("unexpected plan output: %s", planOutput.String())
+	}
 	if err := Run(context.Background(), []string{"--server", server.URL, "repo", "delete", "--id", "8", "--yes"}, nil, &bytes.Buffer{}, nil); err != nil {
 		t.Fatalf("repo delete: %v", err)
 	}
@@ -68,6 +77,7 @@ func TestRunAPICommandsUseGlobalOptionsBeforeVerbs(t *testing.T) {
 		"GET /api/repos",
 		"POST /api/repos",
 		"POST /api/repos/8/reconcile",
+		"GET /api/repos/8/plan",
 		"DELETE /api/repos/8",
 	}
 	if len(requests) != len(want) {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -18,6 +18,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/brianmichel/nomad-compass/internal/manifest"
+	bundleplan "github.com/brianmichel/nomad-compass/internal/plan"
 )
 
 // Run executes a Compass CLI command. It returns an error suitable for
@@ -232,6 +233,27 @@ func newRepoCommand(state *commandState) *cobra.Command {
 	}
 	reconcileCommand.Flags().Int64Var(&reconcileID, "id", 0, "repository ID")
 
+	var planID int64
+	planCommand := &cobra.Command{
+		Use:   "plan",
+		Short: "Show a read-only live plan for one repository",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if planID <= 0 {
+				return errors.New("--id must be greater than zero")
+			}
+			var report PlanReport
+			path := "/api/repos/" + strconv.FormatInt(planID, 10) + "/plan"
+			if err := state.client().get(cmd.Context(), path, &report); err != nil {
+				return err
+			}
+			return writeValue(state.out, state.format, report, func() error {
+				return writeTextPlan(state.out, report)
+			})
+		},
+	}
+	planCommand.Flags().Int64Var(&planID, "id", 0, "repository ID")
+
 	var deleteID int64
 	var unschedule, confirm bool
 	deleteCommand := &cobra.Command{
@@ -260,7 +282,7 @@ func newRepoCommand(state *commandState) *cobra.Command {
 	deleteCommand.Flags().BoolVar(&unschedule, "unschedule", false, "remove managed Nomad resources")
 	deleteCommand.Flags().BoolVar(&confirm, "yes", false, "confirm deletion")
 
-	repoCommand.AddCommand(list, add, reconcileCommand, deleteCommand)
+	repoCommand.AddCommand(list, add, reconcileCommand, planCommand, deleteCommand)
 	return repoCommand
 }
 
@@ -391,33 +413,11 @@ func loadValidatedBundle(ctx context.Context, in io.Reader, filePath string) (*m
 	return bundle, resources, nil
 }
 
-// PlanReport is the stable machine-readable result of bundle plan.
-type PlanReport struct {
-	Bundle     string         `json:"bundle"`
-	Revision   string         `json:"revision"`
-	ComparedTo string         `json:"compared_to,omitempty"`
-	Resources  []PlanResource `json:"resources"`
-	Summary    PlanSummary    `json:"summary"`
-}
-
-// PlanResource describes one offline desired-state transition.
-type PlanResource struct {
-	Action       string `json:"action"`
-	Address      string `json:"address"`
-	Kind         string `json:"kind"`
-	DeleteMode   string `json:"delete_mode"`
-	SpecHash     string `json:"spec_hash,omitempty"`
-	ManifestHash string `json:"manifest_hash,omitempty"`
-}
-
-// PlanSummary counts the transitions in a plan.
-type PlanSummary struct {
-	Create    int `json:"create"`
-	Update    int `json:"update"`
-	Delete    int `json:"delete"`
-	Protected int `json:"protected"`
-	Unchanged int `json:"unchanged"`
-}
+// Plan types are aliases so the CLI and reconciliation service share one
+// planning contract and cannot drift in their action semantics.
+type PlanReport = bundleplan.Report
+type PlanResource = bundleplan.ResourcePlan
+type PlanSummary = bundleplan.Summary
 
 // ValidationReport is the stable machine-readable result of bundle validate.
 type ValidationReport struct {
@@ -489,7 +489,7 @@ func writeTextReport(out io.Writer, report ValidationReport) error {
 }
 
 func runBundlePlan(ctx context.Context, state *commandState, desiredPath, againstPath, revision string) error {
-	desired, desiredResources, err := loadValidatedBundle(ctx, state.in, desiredPath)
+	desired, _, err := loadValidatedBundle(ctx, state.in, desiredPath)
 	if err != nil {
 		return err
 	}
@@ -500,67 +500,12 @@ func runBundlePlan(ctx context.Context, state *commandState, desiredPath, agains
 			return fmt.Errorf("load comparison bundle: %w", err)
 		}
 	}
-
-	desiredByAddress := make(map[string]manifest.Resource, len(desired.Resources))
-	for _, resource := range desired.Resources {
-		desiredByAddress[resource.Address] = resource
-	}
-	previousByAddress := make(map[string]manifest.Resource)
-	if previous != nil {
-		for _, resource := range previous.Resources {
-			previousByAddress[resource.Address] = resource
-		}
-	}
-
-	plan := PlanReport{Bundle: desired.Name, Revision: revision, ComparedTo: againstPath}
-	for _, report := range desiredResources {
-		resource := desiredByAddress[report.Address]
-		action := "create"
-		if old, exists := previousByAddress[resource.Address]; exists {
-			action = "unchanged"
-			if manifest.SpecHash(resource) != manifest.SpecHash(old) || manifest.ManifestHash(resource) != manifest.ManifestHash(old) {
-				action = "update"
-			}
-		}
-		plan.Resources = append(plan.Resources, PlanResource{Action: action, Address: resource.Address, Kind: resource.Kind, DeleteMode: string(resource.DeleteMode), SpecHash: report.SpecHash, ManifestHash: report.ManifestHash})
-		incrementPlanSummary(&plan.Summary, action)
-	}
-	if previous != nil {
-		previousOrdered, err := previous.OrderedResources()
-		if err != nil {
-			return err
-		}
-		for _, resource := range previousOrdered {
-			if _, exists := desiredByAddress[resource.Address]; exists {
-				continue
-			}
-			action := "delete"
-			if resource.DeleteMode == manifest.DeleteModeProtect {
-				action = "protected"
-			}
-			plan.Resources = append(plan.Resources, PlanResource{Action: action, Address: resource.Address, Kind: resource.Kind, DeleteMode: string(resource.DeleteMode), SpecHash: manifest.SpecHash(resource), ManifestHash: manifest.ManifestHash(resource)})
-			incrementPlanSummary(&plan.Summary, action)
-		}
-	}
-
-	return writeValue(state.out, state.format, plan, func() error {
-		return writeTextPlan(state.out, plan)
+	result := bundleplan.CompareBundles(desired, previous)
+	result.Revision = revision
+	result.ComparedTo = againstPath
+	return writeValue(state.out, state.format, result, func() error {
+		return writeTextPlan(state.out, result)
 	})
-}
-
-func incrementPlanSummary(summary *PlanSummary, action string) {
-	switch action {
-	case "create":
-		summary.Create++
-	case "update":
-		summary.Update++
-	case "delete":
-		summary.Delete++
-	case "protected":
-		summary.Protected++
-	case "unchanged":
-		summary.Unchanged++
-	}
 }
 
 func writeTextPlan(out io.Writer, plan PlanReport) error {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -516,7 +516,9 @@ func writeTextPlan(out io.Writer, plan PlanReport) error {
 		symbol := map[string]string{"create": "+", "update": "~", "delete": "-", "protected": "!", "unchanged": "="}[resource.Action]
 		line := fmt.Sprintf("%s %s", symbol, resource.Address)
 		if resource.Action == "protected" {
-			line += " deletion protected"
+			line += " deletion protected (" + resource.Reason + ")"
+		} else if resource.Action == "conflict" {
+			line += " " + resource.Reason
 		}
 		if _, err := fmt.Fprintln(out, line); err != nil {
 			return err

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -1,0 +1,190 @@
+// Package plan computes read-only desired-state plans for bundle resources.
+package plan
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/brianmichel/nomad-compass/internal/manifest"
+	"github.com/brianmichel/nomad-compass/internal/storage"
+)
+
+// Observation is the read-only live state of one tracked resource.
+type Observation struct {
+	Present bool
+	Matches bool
+}
+
+// Observer reports whether a tracked resource still matches the desired
+// resource in the live control plane. It must not mutate state.
+type Observer func(context.Context, manifest.Resource, storage.ManagedResource) (Observation, error)
+
+// Report is the stable machine-readable representation of a bundle plan.
+type Report struct {
+	Bundle     string         `json:"bundle"`
+	Revision   string         `json:"revision"`
+	ComparedTo string         `json:"compared_to,omitempty"`
+	Resources  []ResourcePlan `json:"resources"`
+	Summary    Summary        `json:"summary"`
+}
+
+// ResourcePlan describes one desired-state transition.
+type ResourcePlan struct {
+	Action       string `json:"action"`
+	Address      string `json:"address"`
+	Kind         string `json:"kind"`
+	DeleteMode   string `json:"delete_mode"`
+	SpecHash     string `json:"spec_hash,omitempty"`
+	ManifestHash string `json:"manifest_hash,omitempty"`
+	Reason       string `json:"reason,omitempty"`
+}
+
+// Summary counts the transitions in a plan.
+type Summary struct {
+	Create    int `json:"create"`
+	Update    int `json:"update"`
+	Delete    int `json:"delete"`
+	Protected int `json:"protected"`
+	Unchanged int `json:"unchanged"`
+}
+
+// CompareBundles compares two validated bundles without contacting Nomad.
+func CompareBundles(desired, previous *manifest.Bundle) Report {
+	result := Report{Bundle: desired.Name}
+	desiredByAddress := make(map[string]manifest.Resource, len(desired.Resources))
+	for _, resource := range desired.Resources {
+		desiredByAddress[resource.Address] = resource
+	}
+	previousByAddress := make(map[string]manifest.Resource)
+	if previous != nil {
+		for _, resource := range previous.Resources {
+			previousByAddress[resource.Address] = resource
+		}
+	}
+
+	ordered, _ := desired.OrderedResources()
+	for _, resource := range ordered {
+		action := "create"
+		reason := "resource is not present in the previous bundle"
+		if old, exists := previousByAddress[resource.Address]; exists {
+			action = "unchanged"
+			reason = "native spec and Compass metadata are unchanged"
+			if manifest.SpecHash(resource) != manifest.SpecHash(old) || manifest.ManifestHash(resource) != manifest.ManifestHash(old) {
+				action = "update"
+				reason = "native spec or Compass metadata changed"
+				if resource.Kind == "volume" && resource.DeleteMode == manifest.DeleteModeProtect && manifest.SpecHash(resource) != manifest.SpecHash(old) {
+					action = "protected"
+					reason = "volume replacement is protected"
+				}
+			}
+		}
+		result.add(resourcePlan(resource, action, reason))
+	}
+	if previous != nil {
+		orderedPrevious, _ := previous.OrderedResources()
+		for _, resource := range orderedPrevious {
+			if _, exists := desiredByAddress[resource.Address]; exists {
+				continue
+			}
+			action := "delete"
+			reason := "resource is absent from the desired bundle"
+			if resource.DeleteMode == manifest.DeleteModeProtect {
+				action = "protected"
+				reason = "resource is absent but deletion is protected"
+			}
+			result.add(resourcePlan(resource, action, reason))
+		}
+	}
+	return result
+}
+
+// CompareTracked compares a desired bundle with Compass's managed-resource
+// state and live Nomad observations. It never writes to storage or Nomad.
+func CompareTracked(ctx context.Context, desired *manifest.Bundle, tracked []storage.ManagedResource, observe Observer) (Report, error) {
+	if desired == nil {
+		return Report{}, fmt.Errorf("desired bundle is required")
+	}
+	if observe == nil {
+		return Report{}, fmt.Errorf("resource observer is required")
+	}
+	trackedByAddress := make(map[string]storage.ManagedResource, len(tracked))
+	for _, resource := range tracked {
+		trackedByAddress[resource.Address] = resource
+	}
+	seen := make(map[string]struct{}, len(desired.Resources))
+	ordered, err := desired.OrderedResources()
+	if err != nil {
+		return Report{}, err
+	}
+	result := Report{Bundle: desired.Name}
+	for _, resource := range ordered {
+		seen[resource.Address] = struct{}{}
+		trackedResource, exists := trackedByAddress[resource.Address]
+		if !exists {
+			result.add(resourcePlan(resource, "create", "resource is not managed by Compass"))
+			continue
+		}
+		observation, err := observe(ctx, resource, trackedResource)
+		if err != nil {
+			return Report{}, fmt.Errorf("observe %s: %w", resource.Address, err)
+		}
+		action, reason := "unchanged", "native spec, Compass metadata, and live resource are unchanged"
+		specChanged := !trackedResource.ContentHash.Valid || trackedResource.ContentHash.String != manifest.SpecHash(resource)
+		manifestChanged := !trackedResource.ManifestHash.Valid || trackedResource.ManifestHash.String != manifest.ManifestHash(resource)
+		if !observation.Present {
+			action = "create"
+			reason = "managed resource is missing from Nomad"
+		} else if resource.Kind == "volume" && resource.DeleteMode == manifest.DeleteModeProtect && (specChanged || !observation.Matches) {
+			action = "protected"
+			reason = "volume replacement is protected"
+		} else if !observation.Matches {
+			action = "update"
+			reason = "managed resource has drifted in Nomad"
+		} else if specChanged || manifestChanged || trackedResource.Status != "applied" {
+			action = "update"
+			reason = "native spec, Compass metadata, or recorded status changed"
+		}
+		result.add(resourcePlan(resource, action, reason))
+	}
+	for _, resource := range tracked {
+		if _, exists := seen[resource.Address]; exists {
+			continue
+		}
+		action := "delete"
+		reason := "resource is absent from the desired bundle"
+		if resource.DeleteMode == string(manifest.DeleteModeProtect) {
+			action = "protected"
+			reason = "resource is absent but deletion is protected"
+		}
+		result.add(ResourcePlan{Action: action, Address: resource.Address, Kind: resource.Kind, DeleteMode: resource.DeleteMode, SpecHash: nullString(resource.ContentHash), ManifestHash: nullString(resource.ManifestHash), Reason: reason})
+	}
+	return result, nil
+}
+
+func resourcePlan(resource manifest.Resource, action, reason string) ResourcePlan {
+	return ResourcePlan{Action: action, Address: resource.Address, Kind: resource.Kind, DeleteMode: string(resource.DeleteMode), SpecHash: manifest.SpecHash(resource), ManifestHash: manifest.ManifestHash(resource), Reason: reason}
+}
+
+func (r *Report) add(resource ResourcePlan) {
+	r.Resources = append(r.Resources, resource)
+	switch resource.Action {
+	case "create":
+		r.Summary.Create++
+	case "update":
+		r.Summary.Update++
+	case "delete":
+		r.Summary.Delete++
+	case "protected":
+		r.Summary.Protected++
+	case "unchanged":
+		r.Summary.Unchanged++
+	}
+}
+
+func nullString(value sql.NullString) string {
+	if !value.Valid {
+		return ""
+	}
+	return value.String
+}

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -122,7 +122,15 @@ func CompareTracked(ctx context.Context, desired *manifest.Bundle, tracked []sto
 		seen[resource.Address] = struct{}{}
 		trackedResource, exists := trackedByAddress[resource.Address]
 		if !exists {
-			result.add(resourcePlan(resource, "create", "resource is not managed by Compass"))
+			observation, err := observe(ctx, resource, storage.ManagedResource{})
+			if err != nil {
+				return Report{}, fmt.Errorf("observe %s: %w", resource.Address, err)
+			}
+			if observation.Present {
+				result.add(resourcePlan(resource, "conflict", "an unmanaged live resource already owns the desired identity"))
+			} else {
+				result.add(resourcePlan(resource, "create", "resource is not managed by Compass"))
+			}
 			continue
 		}
 		observation, err := observe(ctx, resource, trackedResource)

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -1,0 +1,67 @@
+package plan
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/brianmichel/nomad-compass/internal/manifest"
+	"github.com/brianmichel/nomad-compass/internal/storage"
+)
+
+func TestCompareTrackedUsesLiveStateAndProtection(t *testing.T) {
+	bundle, err := manifest.Parse([]byte(`bundle "apps" {
+  resource "volume" "data" {
+    name = "data"
+    type = "host"
+  }
+  resource "job" "worker" {
+    datacenters = ["dc1"]
+  }
+}`), "desired.bundle.hcl")
+	if err != nil {
+		t.Fatalf("parse desired bundle: %v", err)
+	}
+	tracked := []storage.ManagedResource{
+		{Address: "volume.data", Kind: "volume", NomadID: stringValue("data"), ContentHash: stringValue(manifest.SpecHash(bundle.Resources[0])), ManifestHash: stringValue(manifest.ManifestHash(bundle.Resources[0])), Status: "applied", DeleteMode: "protect", Subtype: stringValue("host")},
+		{Address: "volume.legacy", Kind: "volume", ContentHash: stringValue("old-spec"), ManifestHash: stringValue("old-manifest"), DeleteMode: "protect"},
+	}
+	observed := map[string]Observation{
+		"volume.data": {Present: true, Matches: true},
+	}
+	result, err := CompareTracked(context.Background(), bundle, tracked, func(_ context.Context, resource manifest.Resource, _ storage.ManagedResource) (Observation, error) {
+		return observed[resource.Address], nil
+	})
+	if err != nil {
+		t.Fatalf("compare tracked: %v", err)
+	}
+	if result.Summary.Create != 1 || result.Summary.Unchanged != 1 || result.Summary.Protected != 1 {
+		t.Fatalf("unexpected summary: %+v", result.Summary)
+	}
+	if result.Resources[0].Action != "unchanged" || result.Resources[1].Action != "create" || result.Resources[2].Action != "protected" {
+		t.Fatalf("unexpected actions: %+v", result.Resources)
+	}
+}
+
+func TestCompareBundlesRemainsOffline(t *testing.T) {
+	previous, err := manifest.Parse([]byte(`bundle "apps" {
+  resource "job" "old" { datacenters = ["dc1"] }
+}`), "previous.bundle.hcl")
+	if err != nil {
+		t.Fatalf("parse previous bundle: %v", err)
+	}
+	desired, err := manifest.Parse([]byte(`bundle "apps" {
+  resource "job" "new" { datacenters = ["dc1"] }
+}`), "desired.bundle.hcl")
+	if err != nil {
+		t.Fatalf("parse desired bundle: %v", err)
+	}
+	result := CompareBundles(desired, previous)
+	if result.Summary.Create != 1 || result.Summary.Delete != 1 {
+		t.Fatalf("unexpected summary: %+v", result.Summary)
+	}
+}
+
+func stringValue(value string) sql.NullString {
+	return sql.NullString{String: value, Valid: value != ""}
+}

--- a/internal/reconcile/manager.go
+++ b/internal/reconcile/manager.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/brianmichel/nomad-compass/internal/manifest"
 	"github.com/brianmichel/nomad-compass/internal/nomadclient"
+	bundleplan "github.com/brianmichel/nomad-compass/internal/plan"
 	"github.com/brianmichel/nomad-compass/internal/repo"
 	"github.com/brianmichel/nomad-compass/internal/storage"
 )
@@ -95,24 +96,7 @@ func (m *Manager) reconcileAll(ctx context.Context) error {
 }
 
 func (m *Manager) reconcileRepo(ctx context.Context, repoRecord *storage.Repository) error {
-	var cred *storage.Credential
-	var payload *storage.CredentialPayload
-	if repoRecord.CredentialID.Valid {
-		var err error
-		cred, err = m.creds.Get(ctx, repoRecord.CredentialID.Int64)
-		if err != nil {
-			return err
-		}
-		if cred == nil {
-			return errors.New("linked credential not found")
-		}
-		payload, err = m.creds.DecryptPayload(cred)
-		if err != nil {
-			return err
-		}
-	}
-
-	snapshot, err := m.git.Sync(ctx, *repoRecord, cred, payload)
+	snapshot, err := m.syncRepo(ctx, repoRecord)
 	if err != nil {
 		// Partial failures should still record the poll event
 		_ = m.repos.UpdatePollTimestamp(ctx, repoRecord.ID)
@@ -141,6 +125,111 @@ func (m *Manager) reconcileRepo(ctx context.Context, repoRecord *storage.Reposit
 	}
 
 	return nil
+}
+
+func (m *Manager) syncRepo(ctx context.Context, repoRecord *storage.Repository) (*repo.Snapshot, error) {
+	if repoRecord == nil {
+		return nil, errors.New("repository is required")
+	}
+	var cred *storage.Credential
+	var payload *storage.CredentialPayload
+	if repoRecord.CredentialID.Valid {
+		var err error
+		cred, err = m.creds.Get(ctx, repoRecord.CredentialID.Int64)
+		if err != nil {
+			return nil, err
+		}
+		if cred == nil {
+			return nil, errors.New("linked credential not found")
+		}
+		payload, err = m.creds.DecryptPayload(cred)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return m.git.Sync(ctx, *repoRecord, cred, payload)
+}
+
+// PlanRepo returns a read-only plan for the bundle currently in a repository.
+// Git synchronization updates only the local checkout; this method does not
+// write Compass tracking state or mutate Nomad.
+func (m *Manager) PlanRepo(ctx context.Context, repoID int64) (*bundleplan.Report, error) {
+	repoRecord, err := m.repos.Get(ctx, repoID)
+	if err != nil {
+		return nil, err
+	}
+	if repoRecord == nil {
+		return nil, errors.New("repository not found")
+	}
+	snapshot, err := m.syncRepo(ctx, repoRecord)
+	if err != nil {
+		return nil, err
+	}
+	if snapshot.Bundle == nil {
+		return nil, errors.New("repository does not contain a Compass bundle")
+	}
+	ordered, err := snapshot.Bundle.OrderedResources()
+	if err != nil {
+		return nil, err
+	}
+	if err := validateBundleResources(ordered); err != nil {
+		return nil, err
+	}
+	if m.managed == nil {
+		return nil, errors.New("managed resource store is required for bundle planning")
+	}
+	tracked, err := m.managed.ListByRepo(ctx, repoRecord.ID)
+	if err != nil {
+		return nil, err
+	}
+	var resourceClient nomadclient.ResourceClient
+	if len(tracked) > 0 {
+		resourceClient, _ = m.nomad.(nomadclient.ResourceClient)
+	}
+	result, err := bundleplan.CompareTracked(ctx, snapshot.Bundle, tracked, func(ctx context.Context, resource manifest.Resource, tracked storage.ManagedResource) (bundleplan.Observation, error) {
+		if resource.Kind == "job" {
+			status, err := m.nomad.JobStatus(ctx, tracked.NomadID.String)
+			if err != nil || status == nil || !status.Exists {
+				return bundleplan.Observation{Present: status != nil && status.Exists}, err
+			}
+			source, err := manifest.NativeJobSource(resource)
+			if err != nil {
+				return bundleplan.Observation{}, err
+			}
+			job, _, err := parseJob(resource.SourcePath, source)
+			if err != nil {
+				return bundleplan.Observation{}, err
+			}
+			job.ID = &tracked.NomadID.String
+			jobPlan, err := m.nomad.PlanJob(ctx, job)
+			if err != nil {
+				return bundleplan.Observation{}, err
+			}
+			return bundleplan.Observation{Present: true, Matches: !jobPlanHasChanges(jobPlan)}, nil
+		}
+		if resourceClient == nil {
+			return bundleplan.Observation{}, errors.New("Nomad client does not support bundle resources")
+		}
+		if resource.Kind == "volume" {
+			drifted, present, err := managedVolumeDrifted(ctx, resourceClient, resource, tracked)
+			return bundleplan.Observation{Present: present, Matches: present && !drifted}, err
+		}
+		policy, err := resourceClient.ObserveACLPolicy(ctx, resource.Name)
+		if err != nil || policy == nil {
+			return bundleplan.Observation{Present: policy != nil}, err
+		}
+		desiredPolicy, err := manifest.CompileACLPolicy(resource)
+		if err != nil {
+			return bundleplan.Observation{}, err
+		}
+		matches := policy.Description == desiredPolicy.Description && strings.TrimSpace(policy.Rules) == strings.TrimSpace(desiredPolicy.Rules)
+		return bundleplan.Observation{Present: true, Matches: matches}, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	result.Revision = snapshot.CommitHash
+	return &result, nil
 }
 
 func (m *Manager) applyJob(ctx context.Context, repoRecord *storage.Repository, jobFile repo.JobFile, snapshot *repo.Snapshot, job *api.Job, submission *api.JobSubmission) (string, error) {

--- a/internal/reconcile/manager.go
+++ b/internal/reconcile/manager.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/hashicorp/nomad/api"
@@ -39,6 +40,7 @@ type Manager struct {
 	nomad    nomadclient.Client
 	interval time.Duration
 	logger   *slog.Logger
+	repoMu   sync.Mutex
 }
 
 // New constructs a reconciliation manager.
@@ -96,6 +98,8 @@ func (m *Manager) reconcileAll(ctx context.Context) error {
 }
 
 func (m *Manager) reconcileRepo(ctx context.Context, repoRecord *storage.Repository) error {
+	m.repoMu.Lock()
+	defer m.repoMu.Unlock()
 	snapshot, err := m.syncRepo(ctx, repoRecord)
 	if err != nil {
 		// Partial failures should still record the poll event
@@ -154,6 +158,8 @@ func (m *Manager) syncRepo(ctx context.Context, repoRecord *storage.Repository) 
 // Git synchronization updates only the local checkout; this method does not
 // write Compass tracking state or mutate Nomad.
 func (m *Manager) PlanRepo(ctx context.Context, repoID int64) (*bundleplan.Report, error) {
+	m.repoMu.Lock()
+	defer m.repoMu.Unlock()
 	repoRecord, err := m.repos.Get(ctx, repoID)
 	if err != nil {
 		return nil, err
@@ -182,13 +188,22 @@ func (m *Manager) PlanRepo(ctx context.Context, repoID int64) (*bundleplan.Repor
 	if err != nil {
 		return nil, err
 	}
-	var resourceClient nomadclient.ResourceClient
-	if len(tracked) > 0 {
-		resourceClient, _ = m.nomad.(nomadclient.ResourceClient)
-	}
+	resourceClient, _ := m.nomad.(nomadclient.ResourceClient)
 	result, err := bundleplan.CompareTracked(ctx, snapshot.Bundle, tracked, func(ctx context.Context, resource manifest.Resource, tracked storage.ManagedResource) (bundleplan.Observation, error) {
 		if resource.Kind == "job" {
-			status, err := m.nomad.JobStatus(ctx, tracked.NomadID.String)
+			candidateID := tracked.NomadID.String
+			if candidateID == "" {
+				source, sourceErr := manifest.NativeJobSource(resource)
+				if sourceErr != nil {
+					return bundleplan.Observation{}, sourceErr
+				}
+				job, _, parseErr := parseJob(resource.SourcePath, source)
+				if parseErr != nil {
+					return bundleplan.Observation{}, parseErr
+				}
+				candidateID = jobID(job)
+			}
+			status, err := m.nomad.JobStatus(ctx, candidateID)
 			if err != nil || status == nil || !status.Exists {
 				return bundleplan.Observation{Present: status != nil && status.Exists}, err
 			}
@@ -200,6 +215,7 @@ func (m *Manager) PlanRepo(ctx context.Context, repoID int64) (*bundleplan.Repor
 			if err != nil {
 				return bundleplan.Observation{}, err
 			}
+			annotateJob(job, repoRecord, repo.JobFile{Path: resource.Address, Content: source}, snapshot, false)
 			job.ID = &tracked.NomadID.String
 			jobPlan, err := m.nomad.PlanJob(ctx, job)
 			if err != nil {
@@ -211,6 +227,22 @@ func (m *Manager) PlanRepo(ctx context.Context, repoID int64) (*bundleplan.Repor
 			return bundleplan.Observation{}, errors.New("Nomad client does not support bundle resources")
 		}
 		if resource.Kind == "volume" {
+			spec, compileErr := manifest.CompileVolume(resource)
+			if compileErr != nil {
+				return bundleplan.Observation{}, compileErr
+			}
+			if spec.Type == "csi" && spec.CSI != nil {
+				id := spec.CSI.ID
+				if id == "" {
+					id = resource.Name
+				}
+				volume, observeErr := resourceClient.ObserveCSIVolume(ctx, id, effectiveNamespace(spec.CSI.Namespace))
+				if tracked.NomadID.Valid {
+					drifted, present, err := managedVolumeDrifted(ctx, resourceClient, resource, tracked)
+					return bundleplan.Observation{Present: present, Matches: present && !drifted}, err
+				}
+				return bundleplan.Observation{Present: volume != nil, Matches: false}, observeErr
+			}
 			drifted, present, err := managedVolumeDrifted(ctx, resourceClient, resource, tracked)
 			return bundleplan.Observation{Present: present, Matches: present && !drifted}, err
 		}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -171,7 +171,11 @@ func (s *Server) handlePlanRepo(w http.ResponseWriter, r *http.Request) {
 	}
 	result, err := s.reconciler.PlanRepo(r.Context(), id)
 	if err != nil {
-		respondErr(w, err)
+		if strings.Contains(err.Error(), "repository not found") {
+			respondStatus(w, http.StatusNotFound, err)
+		} else {
+			respondErr(w, err)
+		}
 		return
 	}
 	respondJSON(w, result)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 
 	"github.com/brianmichel/nomad-compass/internal/nomadclient"
+	"github.com/brianmichel/nomad-compass/internal/plan"
 	"github.com/brianmichel/nomad-compass/internal/storage"
 	"github.com/brianmichel/nomad-compass/internal/web"
 )
@@ -39,6 +40,7 @@ type credentialStore interface {
 
 type reconcileManager interface {
 	ReconcileRepo(ctx context.Context, repoID int64) error
+	PlanRepo(ctx context.Context, repoID int64) (*plan.Report, error)
 	DeleteRepository(ctx context.Context, repoID int64, unschedule bool) error
 	DeleteCredential(ctx context.Context, credentialID int64, deleteRepos bool, unschedule bool) error
 }
@@ -85,6 +87,7 @@ func (s *Server) Handler() http.Handler {
 		api.Get("/repos", s.handleListRepos)
 		api.Post("/repos", s.handleCreateRepo)
 		api.Post("/repos/{id}/reconcile", s.handleTriggerRepo)
+		api.Get("/repos/{id}/plan", s.handlePlanRepo)
 		api.Delete("/repos/{id}", s.handleDeleteRepo)
 
 		api.Get("/credentials", s.handleListCredentials)
@@ -158,6 +161,20 @@ func (s *Server) handleTriggerRepo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	respondStatus(w, http.StatusAccepted, nil)
+}
+
+func (s *Server) handlePlanRepo(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil {
+		respondStatus(w, http.StatusBadRequest, err)
+		return
+	}
+	result, err := s.reconciler.PlanRepo(r.Context(), id)
+	if err != nil {
+		respondErr(w, err)
+		return
+	}
+	respondJSON(w, result)
 }
 
 func (s *Server) handleDeleteRepo(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
Adds the shared planning engine used by offline bundle plans and live Nomad-aware plans.

## Review focus
- Plan action semantics
- Desired-versus-live comparison
- Dry-run behavior and non-mutation guarantees

## Stack
Builds on #19.

## Validation
`go test ./...`