### PR TITLE
Add safe adoption and orphan lifecycle controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ nomad-compass --format json --server http://127.0.0.1:8080 status
 nomad-compass repo list
 nomad-compass repo add --name homelab --url https://github.com/example/homelab.git --branch main
 nomad-compass repo plan --id 1
+nomad-compass repo adopt --id 1 --address volume.existing --yes
 nomad-compass repo orphan list --id 1
 nomad-compass repo orphan forget --id 1 --address volume.legacy --yes
 nomad-compass repo orphan delete --id 1 --address volume.legacy --yes

--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ nomad-compass --format json --server http://127.0.0.1:8080 status
 nomad-compass repo list
 nomad-compass repo add --name homelab --url https://github.com/example/homelab.git --branch main
 nomad-compass repo plan --id 1
+nomad-compass repo orphan list --id 1
+nomad-compass repo orphan forget --id 1 --address volume.legacy --yes
+nomad-compass repo orphan delete --id 1 --address volume.legacy --yes
 nomad-compass repo reconcile --id 1
 nomad-compass repo delete --id 1 --unschedule --yes
 nomad-compass credential list
@@ -91,7 +94,7 @@ nomad-compass credential add --name github --type https-token --token "$GITHUB_T
 nomad-compass credential delete --id 1 --yes
 ```
 
-`repo plan` is read-only: it syncs the repository, observes tracked resources in Nomad, and reports create/update/delete/protected/unchanged actions without mutating Compass state or Nomad. Destructive commands require `--yes`; `--unschedule` explicitly requests Nomad resource removal. Global options such as `--format` and `--server` are placed before the command verbs.
+`repo plan` is read-only: it syncs the repository, observes tracked resources in Nomad, and reports create/update/delete/protected/unchanged actions without mutating Compass state or Nomad. Protected orphan resources must be explicitly forgotten or deleted before their repository can be removed. Destructive commands require `--yes`; `--unschedule` explicitly requests Nomad resource removal. Global options such as `--format` and `--server` are placed before the command verbs.
 
 ### Running locally
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ nomad-compass repo orphan list --id 1
 nomad-compass repo orphan forget --id 1 --address volume.legacy --yes
 nomad-compass repo orphan delete --id 1 --address volume.legacy --yes
 nomad-compass repo reconcile --id 1
+nomad-compass repo reconcile --id 1 --dry-run
 nomad-compass repo delete --id 1 --unschedule --yes
 nomad-compass credential list
 nomad-compass credential add --name github --type https-token --token "$GITHUB_TOKEN"

--- a/internal/cli/api_test.go
+++ b/internal/cli/api_test.go
@@ -23,7 +23,13 @@ func TestRunAPICommandsUseGlobalOptionsBeforeVerbs(t *testing.T) {
 		case r.Method == http.MethodPost && r.URL.Path == "/api/repos":
 			_ = json.NewEncoder(w).Encode(repositoryResponse{ID: 8, Name: "new-repo"})
 		case r.Method == http.MethodPost && r.URL.Path == "/api/repos/8/reconcile":
-			w.WriteHeader(http.StatusAccepted)
+			var request reconcileRequest
+			_ = json.NewDecoder(r.Body).Decode(&request)
+			if request.DryRun {
+				_ = json.NewEncoder(w).Encode(PlanReport{Bundle: "apps", Revision: "a1b2c3d", Summary: PlanSummary{Unchanged: 1}})
+			} else {
+				w.WriteHeader(http.StatusAccepted)
+			}
 		case r.Method == http.MethodGet && r.URL.Path == "/api/repos/8/plan":
 			_ = json.NewEncoder(w).Encode(PlanReport{Bundle: "apps", Revision: "a1b2c3d", Summary: PlanSummary{Unchanged: 1}})
 		case r.Method == http.MethodDelete && r.URL.Path == "/api/repos/8":
@@ -61,6 +67,13 @@ func TestRunAPICommandsUseGlobalOptionsBeforeVerbs(t *testing.T) {
 	if err := Run(context.Background(), []string{"--server", server.URL, "repo", "reconcile", "--id", "8"}, nil, &bytes.Buffer{}, nil); err != nil {
 		t.Fatalf("repo reconcile: %v", err)
 	}
+	var dryRunOutput bytes.Buffer
+	if err := Run(context.Background(), []string{"--server", server.URL, "--format", "json", "repo", "reconcile", "--id", "8", "--dry-run"}, nil, &dryRunOutput, nil); err != nil {
+		t.Fatalf("repo reconcile dry-run: %v", err)
+	}
+	if !strings.Contains(dryRunOutput.String(), `"revision": "a1b2c3d"`) {
+		t.Fatalf("unexpected dry-run output: %s", dryRunOutput.String())
+	}
 	var planOutput bytes.Buffer
 	if err := Run(context.Background(), []string{"--server", server.URL, "--format", "json", "repo", "plan", "--id", "8"}, nil, &planOutput, nil); err != nil {
 		t.Fatalf("repo plan: %v", err)
@@ -76,6 +89,7 @@ func TestRunAPICommandsUseGlobalOptionsBeforeVerbs(t *testing.T) {
 		"GET /api/status",
 		"GET /api/repos",
 		"POST /api/repos",
+		"POST /api/repos/8/reconcile",
 		"POST /api/repos/8/reconcile",
 		"GET /api/repos/8/plan",
 		"DELETE /api/repos/8",

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -282,7 +282,94 @@ func newRepoCommand(state *commandState) *cobra.Command {
 	deleteCommand.Flags().BoolVar(&unschedule, "unschedule", false, "remove managed Nomad resources")
 	deleteCommand.Flags().BoolVar(&confirm, "yes", false, "confirm deletion")
 
-	repoCommand.AddCommand(list, add, reconcileCommand, planCommand, deleteCommand)
+	orphan := &cobra.Command{
+		Use:   "orphan",
+		Short: "Inspect and explicitly manage protected bundle resources",
+	}
+	var orphanID int64
+	listOrphans := &cobra.Command{
+		Use:   "list",
+		Short: "List protected resources",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if orphanID <= 0 {
+				return errors.New("--id must be greater than zero")
+			}
+			var resources []protectedResourceResponse
+			path := "/api/repos/" + strconv.FormatInt(orphanID, 10) + "/orphans"
+			if err := state.client().get(cmd.Context(), path, &resources); err != nil {
+				return err
+			}
+			return writeValue(state.out, state.format, resources, func() error {
+				w := tabwriter.NewWriter(state.out, 0, 4, 2, ' ', 0)
+				if _, err := fmt.Fprintln(w, "ADDRESS\tKIND\tSTATUS\tNOMAD ID\tERROR"); err != nil {
+					return err
+				}
+				for _, resource := range resources {
+					if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", resource.Address, resource.Kind, resource.Status, resource.NomadID, resource.LastError); err != nil {
+						return err
+					}
+				}
+				return w.Flush()
+			})
+		},
+	}
+	listOrphans.Flags().Int64Var(&orphanID, "id", 0, "repository ID")
+
+	var forgetID int64
+	var forgetAddress string
+	var forgetConfirm bool
+	forgetOrphan := &cobra.Command{
+		Use:   "forget",
+		Short: "Forget a protected resource without deleting it from Nomad",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if forgetID <= 0 || strings.TrimSpace(forgetAddress) == "" {
+				return errors.New("--id and --address are required")
+			}
+			if !forgetConfirm {
+				return errors.New("forgetting a protected resource requires --yes")
+			}
+			path := "/api/repos/" + strconv.FormatInt(forgetID, 10) + "/orphans/forget"
+			if err := state.client().post(cmd.Context(), path, orphanActionRequest{Address: forgetAddress}, nil); err != nil {
+				return err
+			}
+			_, err := fmt.Fprintf(state.out, "forgot protected resource %s\n", forgetAddress)
+			return err
+		},
+	}
+	forgetOrphan.Flags().Int64Var(&forgetID, "id", 0, "repository ID")
+	forgetOrphan.Flags().StringVar(&forgetAddress, "address", "", "resource address")
+	forgetOrphan.Flags().BoolVar(&forgetConfirm, "yes", false, "confirm forgetting ownership")
+
+	var deleteOrphanID int64
+	var deleteOrphanAddress string
+	var deleteOrphanConfirm bool
+	deleteOrphan := &cobra.Command{
+		Use:   "delete",
+		Short: "Delete a protected resource from Nomad and Compass",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if deleteOrphanID <= 0 || strings.TrimSpace(deleteOrphanAddress) == "" {
+				return errors.New("--id and --address are required")
+			}
+			if !deleteOrphanConfirm {
+				return errors.New("deleting a protected resource requires --yes")
+			}
+			path := "/api/repos/" + strconv.FormatInt(deleteOrphanID, 10) + "/orphans/delete"
+			if err := state.client().post(cmd.Context(), path, orphanActionRequest{Address: deleteOrphanAddress}, nil); err != nil {
+				return err
+			}
+			_, err := fmt.Fprintf(state.out, "deleted protected resource %s\n", deleteOrphanAddress)
+			return err
+		},
+	}
+	deleteOrphan.Flags().Int64Var(&deleteOrphanID, "id", 0, "repository ID")
+	deleteOrphan.Flags().StringVar(&deleteOrphanAddress, "address", "", "resource address")
+	deleteOrphan.Flags().BoolVar(&deleteOrphanConfirm, "yes", false, "confirm Nomad deletion")
+	orphan.AddCommand(listOrphans, forgetOrphan, deleteOrphan)
+
+	repoCommand.AddCommand(list, add, reconcileCommand, planCommand, orphan, deleteCommand)
 	return repoCommand
 }
 
@@ -698,6 +785,20 @@ type createRepoRequest struct {
 
 type deleteRepoRequest struct {
 	Unschedule bool `json:"unschedule"`
+}
+
+type protectedResourceResponse struct {
+	Address    string `json:"address"`
+	Kind       string `json:"kind"`
+	NomadID    string `json:"nomad_id,omitempty"`
+	Namespace  string `json:"namespace,omitempty"`
+	Status     string `json:"status"`
+	DeleteMode string `json:"delete_mode"`
+	LastError  string `json:"last_error,omitempty"`
+}
+
+type orphanActionRequest struct {
+	Address string `json:"address"`
 }
 
 type createCredentialRequest struct {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -254,6 +254,32 @@ func newRepoCommand(state *commandState) *cobra.Command {
 	}
 	planCommand.Flags().Int64Var(&planID, "id", 0, "repository ID")
 
+	var adoptID int64
+	var adoptAddress string
+	var adoptConfirm bool
+	adoptCommand := &cobra.Command{
+		Use:   "adopt",
+		Short: "Explicitly adopt an existing matching Nomad resource",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if adoptID <= 0 || strings.TrimSpace(adoptAddress) == "" {
+				return errors.New("--id and --address are required")
+			}
+			if !adoptConfirm {
+				return errors.New("adoption requires --yes")
+			}
+			path := "/api/repos/" + strconv.FormatInt(adoptID, 10) + "/adopt"
+			if err := state.client().post(cmd.Context(), path, orphanActionRequest{Address: adoptAddress}, nil); err != nil {
+				return err
+			}
+			_, err := fmt.Fprintf(state.out, "adopted resource %s\n", adoptAddress)
+			return err
+		},
+	}
+	adoptCommand.Flags().Int64Var(&adoptID, "id", 0, "repository ID")
+	adoptCommand.Flags().StringVar(&adoptAddress, "address", "", "resource address")
+	adoptCommand.Flags().BoolVar(&adoptConfirm, "yes", false, "confirm ownership adoption")
+
 	var deleteID int64
 	var unschedule, confirm bool
 	deleteCommand := &cobra.Command{
@@ -369,7 +395,7 @@ func newRepoCommand(state *commandState) *cobra.Command {
 	deleteOrphan.Flags().BoolVar(&deleteOrphanConfirm, "yes", false, "confirm Nomad deletion")
 	orphan.AddCommand(listOrphans, forgetOrphan, deleteOrphan)
 
-	repoCommand.AddCommand(list, add, reconcileCommand, planCommand, orphan, deleteCommand)
+	repoCommand.AddCommand(list, add, reconcileCommand, planCommand, adoptCommand, orphan, deleteCommand)
 	return repoCommand
 }
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -513,12 +513,12 @@ func writeTextPlan(out io.Writer, plan PlanReport) error {
 		return err
 	}
 	for _, resource := range plan.Resources {
-		symbol := map[string]string{"create": "+", "update": "~", "delete": "-", "protected": "!", "unchanged": "="}[resource.Action]
+		symbol := map[string]string{"create": "+", "update": "~", "delete": "-", "protected": "!", "unchanged": "=", "conflict": "?"}[resource.Action]
 		line := fmt.Sprintf("%s %s", symbol, resource.Address)
 		if resource.Action == "protected" {
 			line += " deletion protected (" + resource.Reason + ")"
 		} else if resource.Action == "conflict" {
-			line += " " + resource.Reason
+			line += " ownership conflict: " + resource.Reason
 		}
 		if _, err := fmt.Fprintln(out, line); err != nil {
 			return err
@@ -527,7 +527,7 @@ func writeTextPlan(out io.Writer, plan PlanReport) error {
 	if _, err := fmt.Fprintln(out, "\nPlan:"); err != nil {
 		return err
 	}
-	for _, item := range []struct {
+	items := []struct {
 		count int
 		name  string
 	}{
@@ -536,7 +536,12 @@ func writeTextPlan(out io.Writer, plan PlanReport) error {
 		{plan.Summary.Delete, "delete"},
 		{plan.Summary.Protected, "protected"},
 		{plan.Summary.Unchanged, "unchanged"},
-	} {
+		{plan.Summary.Conflict, "conflict"},
+	}
+	for _, item := range items {
+		if item.name == "conflict" && item.count == 0 {
+			continue
+		}
 		if _, err := fmt.Fprintf(out, "  %d %s\n", item.count, item.name); err != nil {
 			return err
 		}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -212,6 +212,7 @@ func newRepoCommand(state *commandState) *cobra.Command {
 	add.Flags().Int64Var(&credentialID, "credential-id", 0, "credential ID to use for Git authentication")
 
 	var reconcileID int64
+	var reconcileDryRun bool
 	reconcileCommand := &cobra.Command{
 		Use:   "reconcile",
 		Short: "Trigger reconciliation for one repository",
@@ -221,6 +222,13 @@ func newRepoCommand(state *commandState) *cobra.Command {
 				return errors.New("--id must be greater than zero")
 			}
 			path := "/api/repos/" + strconv.FormatInt(reconcileID, 10) + "/reconcile"
+			if reconcileDryRun {
+				var report PlanReport
+				if err := state.client().post(cmd.Context(), path, reconcileRequest{DryRun: true}, &report); err != nil {
+					return err
+				}
+				return writeValue(state.out, state.format, report, func() error { return writeTextPlan(state.out, report) })
+			}
 			var response map[string]string
 			if err := state.client().post(cmd.Context(), path, nil, &response); err != nil {
 				return err
@@ -232,6 +240,7 @@ func newRepoCommand(state *commandState) *cobra.Command {
 		},
 	}
 	reconcileCommand.Flags().Int64Var(&reconcileID, "id", 0, "repository ID")
+	reconcileCommand.Flags().BoolVar(&reconcileDryRun, "dry-run", false, "show the live plan without applying changes")
 
 	var planID int64
 	planCommand := &cobra.Command{
@@ -799,6 +808,10 @@ type credentialResponse struct {
 	Type      string    `json:"type"`
 	CreatedAt time.Time `json:"created_at,omitempty"`
 	UpdatedAt time.Time `json:"updated_at,omitempty"`
+}
+
+type reconcileRequest struct {
+	DryRun bool `json:"dry_run"`
 }
 
 type createRepoRequest struct {

--- a/internal/nomadclient/resources.go
+++ b/internal/nomadclient/resources.go
@@ -10,6 +10,15 @@ import (
 
 // ResourceClient contains Nomad operations for bundle-managed resources. It
 // is separate from Client so existing job-only fakes remain source-compatible.
+// ResourceLookup provides read-only name-based discovery used for planning
+// and unmanaged-resource collision checks. It is separate from ResourceClient
+// so existing fakes and apply paths remain source-compatible.
+type ResourceLookup interface {
+	FindHostVolume(ctx context.Context, name, namespace string) (*api.HostVolume, error)
+	FindCSIVolume(ctx context.Context, name, namespace string) (*api.CSIVolume, error)
+	ObserveACLPolicy(ctx context.Context, name string) (*api.ACLPolicy, error)
+}
+
 type ResourceClient interface {
 	Client
 	ApplyHostVolume(ctx context.Context, volume *api.HostVolume) (*api.HostVolume, error)
@@ -36,6 +45,20 @@ func (a *API) ApplyHostVolume(_ context.Context, volume *api.HostVolume) (*api.H
 		return nil, errors.New("Nomad returned an empty host volume response")
 	}
 	return resp.Volume, nil
+}
+
+func (a *API) FindHostVolume(ctx context.Context, name, namespace string) (*api.HostVolume, error) {
+	stubs, _, err := a.client.HostVolumes().List(&api.HostVolumeListRequest{}, &api.QueryOptions{Namespace: namespace})
+	if err != nil {
+		return nil, err
+	}
+	for _, stub := range stubs {
+		if stub == nil || stub.Name != name || effectiveNamespace(stub.Namespace) != effectiveNamespace(namespace) {
+			continue
+		}
+		return a.ObserveHostVolume(ctx, stub.ID, stub.Namespace)
+	}
+	return nil, nil
 }
 
 func (a *API) ObserveHostVolume(_ context.Context, id, namespace string) (*api.HostVolume, error) {
@@ -88,6 +111,20 @@ func (a *API) ApplyCSIVolume(_ context.Context, volume *api.CSIVolume) (*api.CSI
 	return resp.Volumes[0], nil
 }
 
+func (a *API) FindCSIVolume(ctx context.Context, name, namespace string) (*api.CSIVolume, error) {
+	stubs, _, err := a.client.CSIVolumes().List(&api.QueryOptions{Namespace: namespace})
+	if err != nil {
+		return nil, err
+	}
+	for _, stub := range stubs {
+		if stub == nil || stub.Name != name || effectiveNamespace(stub.Namespace) != effectiveNamespace(namespace) {
+			continue
+		}
+		return a.ObserveCSIVolume(ctx, stub.ID, stub.Namespace)
+	}
+	return nil, nil
+}
+
 func (a *API) ObserveCSIVolume(_ context.Context, id, namespace string) (*api.CSIVolume, error) {
 	if id == "" {
 		return nil, nil
@@ -138,6 +175,13 @@ func (a *API) DeleteACLPolicy(_ context.Context, name string) error {
 		return nil
 	}
 	return err
+}
+
+func effectiveNamespace(namespace string) string {
+	if namespace == "" {
+		return "default"
+	}
+	return namespace
 }
 
 func isNotFound(err error) bool {

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -20,6 +20,10 @@ type Observation struct {
 // resource in the live control plane. It must not mutate state.
 type Observer func(context.Context, manifest.Resource, storage.ManagedResource) (Observation, error)
 
+// Lookup reports whether an unmanaged Nomad resource already exists by its
+// desired name. It must not mutate state.
+type Lookup func(context.Context, manifest.Resource) (bool, error)
+
 // Report is the stable machine-readable representation of a bundle plan.
 type Report struct {
 	Bundle     string         `json:"bundle"`
@@ -47,6 +51,7 @@ type Summary struct {
 	Delete    int `json:"delete"`
 	Protected int `json:"protected"`
 	Unchanged int `json:"unchanged"`
+	Conflict  int `json:"conflict"`
 }
 
 // CompareBundles compares two validated bundles without contacting Nomad.
@@ -102,6 +107,11 @@ func CompareBundles(desired, previous *manifest.Bundle) Report {
 // CompareTracked compares a desired bundle with Compass's managed-resource
 // state and live Nomad observations. It never writes to storage or Nomad.
 func CompareTracked(ctx context.Context, desired *manifest.Bundle, tracked []storage.ManagedResource, observe Observer) (Report, error) {
+	return CompareTrackedWithLookup(ctx, desired, tracked, observe, nil)
+}
+
+// CompareTrackedWithLookup also reports unmanaged Nomad name collisions.
+func CompareTrackedWithLookup(ctx context.Context, desired *manifest.Bundle, tracked []storage.ManagedResource, observe Observer, lookup Lookup) (Report, error) {
 	if desired == nil {
 		return Report{}, fmt.Errorf("desired bundle is required")
 	}
@@ -122,15 +132,26 @@ func CompareTracked(ctx context.Context, desired *manifest.Bundle, tracked []sto
 		seen[resource.Address] = struct{}{}
 		trackedResource, exists := trackedByAddress[resource.Address]
 		if !exists {
-			observation, err := observe(ctx, resource, storage.ManagedResource{})
-			if err != nil {
-				return Report{}, fmt.Errorf("observe %s: %w", resource.Address, err)
-			}
-			if observation.Present {
-				result.add(resourcePlan(resource, "conflict", "an unmanaged live resource already owns the desired identity"))
+			if lookup != nil {
+				alreadyExists, err := lookup(ctx, resource)
+				if err != nil {
+					return Report{}, fmt.Errorf("lookup %s: %w", resource.Address, err)
+				}
+				if alreadyExists {
+					result.add(resourcePlan(resource, "conflict", "resource exists in Nomad but is not managed by Compass"))
+					continue
+				}
 			} else {
-				result.add(resourcePlan(resource, "create", "resource is not managed by Compass"))
+				observation, err := observe(ctx, resource, storage.ManagedResource{})
+				if err != nil {
+					return Report{}, fmt.Errorf("observe %s: %w", resource.Address, err)
+				}
+				if observation.Present {
+					result.add(resourcePlan(resource, "conflict", "an unmanaged live resource already owns the desired identity"))
+					continue
+				}
 			}
+			result.add(resourcePlan(resource, "create", "resource is not managed by Compass"))
 			continue
 		}
 		observation, err := observe(ctx, resource, trackedResource)
@@ -187,6 +208,8 @@ func (r *Report) add(resource ResourcePlan) {
 		r.Summary.Protected++
 	case "unchanged":
 		r.Summary.Unchanged++
+	case "conflict":
+		r.Summary.Conflict++
 	}
 }
 

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -43,6 +43,31 @@ func TestCompareTrackedUsesLiveStateAndProtection(t *testing.T) {
 	}
 }
 
+func TestCompareTrackedReportsUnmanagedCollision(t *testing.T) {
+	bundle, err := manifest.Parse([]byte(`bundle "apps" {
+  resource "job" "worker" {
+    datacenters = ["dc1"]
+  }
+}`), "desired.bundle.hcl")
+	if err != nil {
+		t.Fatalf("parse desired bundle: %v", err)
+	}
+	result, err := CompareTrackedWithLookup(context.Background(), bundle, nil,
+		func(context.Context, manifest.Resource, storage.ManagedResource) (Observation, error) {
+			t.Fatal("observer called for an unmanaged resource")
+			return Observation{}, nil
+		},
+		func(_ context.Context, resource manifest.Resource) (bool, error) {
+			return resource.Address == "job.worker", nil
+		})
+	if err != nil {
+		t.Fatalf("compare with lookup: %v", err)
+	}
+	if result.Summary.Conflict != 1 || result.Resources[0].Action != "conflict" {
+		t.Fatalf("unexpected collision result: %+v", result)
+	}
+}
+
 func TestCompareBundlesRemainsOffline(t *testing.T) {
 	previous, err := manifest.Parse([]byte(`bundle "apps" {
   resource "job" "old" { datacenters = ["dc1"] }

--- a/internal/reconcile/manager.go
+++ b/internal/reconcile/manager.go
@@ -189,7 +189,41 @@ func (m *Manager) PlanRepo(ctx context.Context, repoID int64) (*bundleplan.Repor
 		return nil, err
 	}
 	resourceClient, _ := m.nomad.(nomadclient.ResourceClient)
-	result, err := bundleplan.CompareTracked(ctx, snapshot.Bundle, tracked, func(ctx context.Context, resource manifest.Resource, tracked storage.ManagedResource) (bundleplan.Observation, error) {
+	var lookup bundleplan.Lookup
+	if resourceLookup, ok := m.nomad.(nomadclient.ResourceLookup); ok {
+		lookup = func(ctx context.Context, resource manifest.Resource) (bool, error) {
+			switch resource.Kind {
+			case "job":
+				status, err := m.nomad.JobStatus(ctx, resource.Name)
+				return status != nil && status.Exists, err
+			case "acl_policy":
+				policy, err := resourceLookup.ObserveACLPolicy(ctx, resource.Name)
+				return policy != nil, err
+			case "volume":
+				spec, err := manifest.CompileVolume(resource)
+				if err != nil {
+					return false, err
+				}
+				if spec.Type == "csi" && resourceClient != nil {
+					id := spec.CSI.ID
+					if id == "" {
+						id = resource.Name
+					}
+					volume, err := resourceClient.ObserveCSIVolume(ctx, id, effectiveNamespace(spec.CSI.Namespace))
+					return volume != nil, err
+				}
+				if spec.Type == "host" {
+					volume, err := resourceLookup.FindHostVolume(ctx, spec.Host.Name, spec.Host.Namespace)
+					return volume != nil, err
+				}
+				volume, err := resourceLookup.FindCSIVolume(ctx, spec.CSI.Name, spec.CSI.Namespace)
+				return volume != nil, err
+			default:
+				return false, nil
+			}
+		}
+	}
+	result, err := bundleplan.CompareTrackedWithLookup(ctx, snapshot.Bundle, tracked, func(ctx context.Context, resource manifest.Resource, tracked storage.ManagedResource) (bundleplan.Observation, error) {
 		if resource.Kind == "job" {
 			candidateID := tracked.NomadID.String
 			if candidateID == "" {
@@ -256,7 +290,7 @@ func (m *Manager) PlanRepo(ctx context.Context, repoID int64) (*bundleplan.Repor
 		}
 		matches := policy.Description == desiredPolicy.Description && strings.TrimSpace(policy.Rules) == strings.TrimSpace(desiredPolicy.Rules)
 		return bundleplan.Observation{Present: true, Matches: matches}, nil
-	})
+	}, lookup)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/reconcile/manager.go
+++ b/internal/reconcile/manager.go
@@ -911,7 +911,7 @@ func (m *Manager) ensureBundle(ctx context.Context, repoRecord *storage.Reposito
 			continue
 		}
 		if resource.DeleteMode == string(manifest.DeleteModeProtect) {
-			_ = m.managed.Upsert(ctx, storage.ManagedResourceInput{
+			if err := m.managed.Upsert(ctx, storage.ManagedResourceInput{
 				RepoID:       repoRecord.ID,
 				Address:      resource.Address,
 				Kind:         resource.Kind,
@@ -926,7 +926,9 @@ func (m *Manager) ensureBundle(ctx context.Context, repoRecord *storage.Reposito
 				DeleteMode:   resource.DeleteMode,
 				Subtype:      resource.Subtype.String,
 				DependsOn:    resource.DependsOn,
-			})
+			}); err != nil {
+				return fmt.Errorf("record protected orphan %q: %w", resource.Address, err)
+			}
 			continue
 		}
 		if err := deleteManagedResource(ctx, resourceClient, resource); err != nil {

--- a/internal/reconcile/manager.go
+++ b/internal/reconcile/manager.go
@@ -298,6 +298,143 @@ func (m *Manager) PlanRepo(ctx context.Context, repoID int64) (*bundleplan.Repor
 	return &result, nil
 }
 
+// AdoptBundleResource records explicit ownership of an unmanaged resource
+// after verifying that the live Nomad object matches the desired bundle body.
+// Adoption never changes the Nomad object.
+func (m *Manager) AdoptBundleResource(ctx context.Context, repoID int64, address string) error {
+	repoRecord, err := m.repos.Get(ctx, repoID)
+	if err != nil {
+		return err
+	}
+	if repoRecord == nil {
+		return errors.New("repository not found")
+	}
+	snapshot, err := m.syncRepo(ctx, repoRecord)
+	if err != nil {
+		return err
+	}
+	return m.adoptBundleResource(ctx, repoID, snapshot, address)
+}
+
+func (m *Manager) adoptBundleResource(ctx context.Context, repoID int64, snapshot *repo.Snapshot, address string) error {
+	if snapshot == nil || snapshot.Bundle == nil {
+		return errors.New("repository does not contain a Compass bundle")
+	}
+	ordered, err := snapshot.Bundle.OrderedResources()
+	if err != nil {
+		return err
+	}
+	if err := validateBundleResources(ordered); err != nil {
+		return err
+	}
+	var resource manifest.Resource
+	found := false
+	for _, candidate := range ordered {
+		if candidate.Address == address {
+			resource = candidate
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("bundle resource %q not found", address)
+	}
+	if m.managed == nil {
+		return errors.New("managed resource store is required for adoption")
+	}
+	tracked, err := m.managedResources(ctx, repoID)
+	if err != nil {
+		return err
+	}
+	if _, exists := tracked[address]; exists {
+		return fmt.Errorf("resource %q is already managed by Compass", address)
+	}
+
+	var nomadID, namespace, subtype string
+	if resource.Kind == "job" {
+		status, err := m.nomad.JobStatus(ctx, resource.Name)
+		if err != nil {
+			return err
+		}
+		if status == nil || !status.Exists {
+			return fmt.Errorf("Nomad job %q does not exist", resource.Name)
+		}
+		source, err := manifest.NativeJobSource(resource)
+		if err != nil {
+			return err
+		}
+		job, _, err := parseJob(resource.SourcePath, source)
+		if err != nil {
+			return err
+		}
+		job.ID = &resource.Name
+		jobPlan, err := m.nomad.PlanJob(ctx, job)
+		if err != nil {
+			return err
+		}
+		if jobPlanHasChanges(jobPlan) {
+			return fmt.Errorf("Nomad job %q does not match desired bundle resource", resource.Name)
+		}
+		nomadID = resource.Name
+	} else {
+		lookup, ok := m.nomad.(nomadclient.ResourceLookup)
+		if !ok {
+			return errors.New("Nomad client does not support resource adoption lookups")
+		}
+		switch resource.Kind {
+		case "volume":
+			spec, err := manifest.CompileVolume(resource)
+			if err != nil {
+				return err
+			}
+			if spec.Type == "host" {
+				volume, err := lookup.FindHostVolume(ctx, spec.Host.Name, spec.Host.Namespace)
+				if err != nil {
+					return fmt.Errorf("find host volume %q: %w", resource.Name, err)
+				}
+				if volume == nil {
+					return fmt.Errorf("host volume %q not found", resource.Name)
+				}
+				if !hostVolumeEquivalent(spec.Host, volume) {
+					return fmt.Errorf("host volume %q does not match desired bundle resource", resource.Name)
+				}
+				nomadID, namespace, subtype = volume.ID, volume.Namespace, "host"
+			} else {
+				volume, err := lookup.FindCSIVolume(ctx, spec.CSI.Name, spec.CSI.Namespace)
+				if err != nil {
+					return fmt.Errorf("find CSI volume %q: %w", resource.Name, err)
+				}
+				if volume == nil {
+					return fmt.Errorf("CSI volume %q not found", resource.Name)
+				}
+				if !csiVolumeEquivalent(spec.CSI, volume) {
+					return fmt.Errorf("CSI volume %q does not match desired bundle resource", resource.Name)
+				}
+				nomadID, namespace, subtype = volume.ID, volume.Namespace, "csi"
+			}
+		case "acl_policy":
+			policy, err := lookup.ObserveACLPolicy(ctx, resource.Name)
+			if err != nil {
+				return fmt.Errorf("find ACL policy %q: %w", resource.Name, err)
+			}
+			if policy == nil {
+				return fmt.Errorf("ACL policy %q not found", resource.Name)
+			}
+			desired, err := manifest.CompileACLPolicy(resource)
+			if err != nil {
+				return err
+			}
+			if policy.Description != desired.Description || strings.TrimSpace(policy.Rules) != strings.TrimSpace(desired.Rules) {
+				return fmt.Errorf("ACL policy %q does not match desired bundle resource", resource.Name)
+			}
+			nomadID = resource.Name
+		default:
+			return fmt.Errorf("resource kind %q cannot be adopted", resource.Kind)
+		}
+	}
+	return m.upsertManagedResource(ctx, repoID, snapshot, resource, nomadID, namespace, manifest.SpecHash(resource), manifest.ManifestHash(resource), "applied", "", subtype)
+}
+
 func (m *Manager) applyJob(ctx context.Context, repoRecord *storage.Repository, jobFile repo.JobFile, snapshot *repo.Snapshot, job *api.Job, submission *api.JobSubmission) (string, error) {
 	if job == nil || submission == nil {
 		return "", errors.New("job and submission are required")

--- a/internal/reconcile/manager.go
+++ b/internal/reconcile/manager.go
@@ -311,6 +311,77 @@ func (m *Manager) applyJob(ctx context.Context, repoRecord *storage.Repository, 
 	return jobID(job), nil
 }
 
+// ListProtectedResources returns resources that Compass retained after they
+// were removed from a bundle or otherwise require explicit lifecycle action.
+func (m *Manager) ListProtectedResources(ctx context.Context, repoID int64) ([]storage.ManagedResource, error) {
+	if m.managed == nil {
+		return nil, errors.New("managed resource store is required")
+	}
+	resources, err := m.managed.ListByRepo(ctx, repoID)
+	if err != nil {
+		return nil, err
+	}
+	protected := make([]storage.ManagedResource, 0)
+	for _, resource := range resources {
+		if resource.DeleteMode == string(manifest.DeleteModeProtect) {
+			protected = append(protected, resource)
+		}
+	}
+	return protected, nil
+}
+
+// ForgetProtectedResource removes Compass ownership metadata without deleting
+// the Nomad resource. This is intentionally explicit because it creates an
+// unmanaged resource by design.
+func (m *Manager) ForgetProtectedResource(ctx context.Context, repoID int64, address string) error {
+	resource, err := m.protectedResource(ctx, repoID, address)
+	if err != nil {
+		return err
+	}
+	if resource.Status != "protected" {
+		return fmt.Errorf("resource %q is not a protected orphan", address)
+	}
+	return m.managed.Delete(ctx, repoID, address)
+}
+
+// DeleteProtectedResource removes a protected orphan from Nomad and Compass.
+func (m *Manager) DeleteProtectedResource(ctx context.Context, repoID int64, address string) error {
+	resource, err := m.protectedResource(ctx, repoID, address)
+	if err != nil {
+		return err
+	}
+	if resource.Status != "protected" {
+		return fmt.Errorf("resource %q is not a protected orphan", address)
+	}
+	if resource.Kind == "job" {
+		if err := m.nomad.DeregisterJob(ctx, resource.NomadID.String, true); err != nil {
+			return err
+		}
+	} else {
+		client, ok := m.nomad.(nomadclient.ResourceClient)
+		if !ok {
+			return errors.New("Nomad client does not support bundle resource cleanup")
+		}
+		if err := deleteManagedResource(ctx, client, resource); err != nil {
+			return err
+		}
+	}
+	return m.managed.Delete(ctx, repoID, address)
+}
+
+func (m *Manager) protectedResource(ctx context.Context, repoID int64, address string) (storage.ManagedResource, error) {
+	resources, err := m.ListProtectedResources(ctx, repoID)
+	if err != nil {
+		return storage.ManagedResource{}, err
+	}
+	for _, resource := range resources {
+		if resource.Address == address {
+			return resource, nil
+		}
+	}
+	return storage.ManagedResource{}, fmt.Errorf("protected resource %q not found", address)
+}
+
 // DeleteRepository removes repository metadata and optionally unschedules jobs.
 func (m *Manager) DeleteRepository(ctx context.Context, repoID int64, unschedule bool) error {
 	repoRecord, err := m.repos.Get(ctx, repoID)
@@ -319,6 +390,11 @@ func (m *Manager) DeleteRepository(ctx context.Context, repoID int64, unschedule
 	}
 	if repoRecord == nil {
 		return errors.New("repository not found")
+	}
+	if protected, err := m.ListProtectedResources(ctx, repoID); err != nil {
+		return err
+	} else if len(protected) > 0 {
+		return fmt.Errorf("repository has %d protected resource(s); use repo orphan list, forget, or delete first", len(protected))
 	}
 
 	if unschedule {

--- a/internal/reconcile/manager_test.go
+++ b/internal/reconcile/manager_test.go
@@ -241,6 +241,102 @@ func TestProtectedResourceLifecycleRequiresExplicitAction(t *testing.T) {
 	}
 }
 
+func TestAdoptBundleResourceRecordsMatchingHostVolumeWithoutMutation(t *testing.T) {
+	ctx := context.Background()
+	manager, repoRecord, managed, fake := newBundleManager(t)
+	bundle, err := manifest.Parse([]byte(`bundle "compass" {
+  resource "volume" "data" {
+    name = "data"
+    type = "host"
+    plugin_id = "mkdir"
+  }
+}`), "compass.bundle.hcl")
+	if err != nil {
+		t.Fatalf("parse bundle: %v", err)
+	}
+	fake.hostVolume = &api.HostVolume{ID: "host-volume-id", Name: "data", PluginID: "mkdir"}
+	if err := manager.adoptBundleResource(ctx, repoRecord.ID, &repomodel.Snapshot{CommitHash: "commit-1", Bundle: bundle}, "volume.data"); err != nil {
+		t.Fatalf("adopt host volume: %v", err)
+	}
+	resources, err := managed.ListByRepo(ctx, repoRecord.ID)
+	if err != nil || len(resources) != 1 || resources[0].NomadID.String != "host-volume-id" {
+		t.Fatalf("unexpected adopted resource: %v %#v", err, resources)
+	}
+	if len(fake.resourceCalls) != 0 {
+		t.Fatalf("adoption mutated Nomad: %v", fake.resourceCalls)
+	}
+}
+
+func TestAdoptBundleResourceRejectsMismatchedHostVolume(t *testing.T) {
+	ctx := context.Background()
+	manager, repoRecord, managed, fake := newBundleManager(t)
+	bundle, err := manifest.Parse([]byte(`bundle "compass" {
+  resource "volume" "data" {
+    name = "data"
+    type = "host"
+    plugin_id = "mkdir"
+  }
+}`), "compass.bundle.hcl")
+	if err != nil {
+		t.Fatalf("parse bundle: %v", err)
+	}
+	fake.hostVolume = &api.HostVolume{ID: "host-volume-id", Name: "data", PluginID: "other"}
+	if err := manager.adoptBundleResource(ctx, repoRecord.ID, &repomodel.Snapshot{CommitHash: "commit-1", Bundle: bundle}, "volume.data"); err == nil || !strings.Contains(err.Error(), "does not match") {
+		t.Fatalf("expected mismatch error, got %v", err)
+	}
+	resources, err := managed.ListByRepo(ctx, repoRecord.ID)
+	if err != nil || len(resources) != 0 {
+		t.Fatalf("mismatched resource was adopted: %v %#v", err, resources)
+	}
+}
+
+func TestAdoptBundleResourceRecordsMatchingJob(t *testing.T) {
+	ctx := context.Background()
+	manager, repoRecord, managed, fake := newBundleManager(t)
+	bundle, err := manifest.Parse([]byte(`bundle "compass" {
+  resource "job" "worker" {
+    datacenters = ["dc1"]
+  }
+}`), "compass.bundle.hcl")
+	if err != nil {
+		t.Fatalf("parse bundle: %v", err)
+	}
+	fake.jobStatuses = map[string]*nomadclient.JobStatus{"worker": {ID: "worker", Exists: true}}
+	fake.planResponses = map[string]*api.JobPlanResponse{"worker": {}}
+	if err := manager.adoptBundleResource(ctx, repoRecord.ID, &repomodel.Snapshot{CommitHash: "commit-1", Bundle: bundle}, "job.worker"); err != nil {
+		t.Fatalf("adopt job: %v", err)
+	}
+	resources, err := managed.ListByRepo(ctx, repoRecord.ID)
+	if err != nil || len(resources) != 1 || resources[0].NomadID.String != "worker" {
+		t.Fatalf("unexpected adopted job: %v %#v", err, resources)
+	}
+	if fake.registerCalls != 0 {
+		t.Fatalf("adoption registered a job: %d", fake.registerCalls)
+	}
+}
+
+func TestAdoptBundleResourceRejectsJobDrift(t *testing.T) {
+	ctx := context.Background()
+	manager, repoRecord, managed, fake := newBundleManager(t)
+	bundle, err := manifest.Parse([]byte(`bundle "compass" {
+  resource "job" "worker" {
+    datacenters = ["dc1"]
+  }
+}`), "compass.bundle.hcl")
+	if err != nil {
+		t.Fatalf("parse bundle: %v", err)
+	}
+	fake.jobStatuses = map[string]*nomadclient.JobStatus{"worker": {ID: "worker", Exists: true}}
+	fake.planResponses = map[string]*api.JobPlanResponse{"worker": {Diff: &api.JobDiff{Fields: []*api.FieldDiff{{Name: "datacenters", Old: "dc1", New: "dc2"}}}}}
+	if err := manager.adoptBundleResource(ctx, repoRecord.ID, &repomodel.Snapshot{CommitHash: "commit-1", Bundle: bundle}, "job.worker"); err == nil || !strings.Contains(err.Error(), "does not match") {
+		t.Fatalf("expected job mismatch error, got %v", err)
+	}
+	resources, err := managed.ListByRepo(ctx, repoRecord.ID)
+	if err != nil || len(resources) != 0 {
+		t.Fatalf("drifted job was adopted: %v %#v", err, resources)
+	}
+}
+
 func TestBundleJobIdentitySurvivesBundlePathChange(t *testing.T) {
 	ctx := context.Background()
 	manager, repoRecord, managed, fake := newBundleManager(t)
@@ -1066,6 +1162,17 @@ func (f *fakeNomad) ApplyHostVolume(_ context.Context, volume *api.HostVolume) (
 	}
 	f.hostVolume = &copy
 	return &copy, nil
+}
+
+func (f *fakeNomad) FindHostVolume(_ context.Context, name, _ string) (*api.HostVolume, error) {
+	if f.hostVolume == nil || f.hostVolume.Name != name {
+		return nil, nil
+	}
+	return f.hostVolume, nil
+}
+
+func (f *fakeNomad) FindCSIVolume(context.Context, string, string) (*api.CSIVolume, error) {
+	return nil, nil
 }
 
 func (f *fakeNomad) ObserveHostVolume(_ context.Context, id, _ string) (*api.HostVolume, error) {

--- a/internal/reconcile/manager_test.go
+++ b/internal/reconcile/manager_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/nomad/api"
@@ -202,11 +203,42 @@ func newBundleManager(t *testing.T) (*Manager, *storage.Repository, *storage.Man
 	}
 	fake := &fakeNomad{}
 	return &Manager{
+		repos:   repoStore,
 		files:   storage.NewRepoFileStore(db),
 		managed: storage.NewManagedResourceStore(db),
 		nomad:   fake,
 		logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}, repoRecord, storage.NewManagedResourceStore(db), fake
+}
+
+func TestProtectedResourceLifecycleRequiresExplicitAction(t *testing.T) {
+	ctx := context.Background()
+	manager, repoRecord, managed, _ := newBundleManager(t)
+	if err := managed.Upsert(ctx, storage.ManagedResourceInput{
+		RepoID:     repoRecord.ID,
+		Address:    "volume.legacy",
+		Kind:       "volume",
+		NomadID:    "legacy-id",
+		Status:     "protected",
+		DeleteMode: string(manifest.DeleteModeProtect),
+	}); err != nil {
+		t.Fatalf("upsert protected resource: %v", err)
+	}
+
+	protected, err := manager.ListProtectedResources(ctx, repoRecord.ID)
+	if err != nil || len(protected) != 1 || protected[0].Address != "volume.legacy" {
+		t.Fatalf("unexpected protected resources: %v %#v", err, protected)
+	}
+	if err := manager.DeleteRepository(ctx, repoRecord.ID, false); err == nil || !strings.Contains(err.Error(), "protected resource") {
+		t.Fatalf("expected repository deletion guard, got %v", err)
+	}
+	if err := manager.ForgetProtectedResource(ctx, repoRecord.ID, "volume.legacy"); err != nil {
+		t.Fatalf("forget protected resource: %v", err)
+	}
+	protected, err = manager.ListProtectedResources(ctx, repoRecord.ID)
+	if err != nil || len(protected) != 0 {
+		t.Fatalf("protected resource was not forgotten: %v %#v", err, protected)
+	}
 }
 
 func TestBundleJobIdentitySurvivesBundlePathChange(t *testing.T) {

--- a/internal/server/response.go
+++ b/internal/server/response.go
@@ -86,6 +86,28 @@ type repositoryJobResponse struct {
 	Allocations          []nomadclient.AllocationStatus `json:"allocations,omitempty"`
 }
 
+type protectedResourceResponse struct {
+	Address    string  `json:"address"`
+	Kind       string  `json:"kind"`
+	NomadID    *string `json:"nomad_id,omitempty"`
+	Namespace  *string `json:"namespace,omitempty"`
+	Status     string  `json:"status"`
+	DeleteMode string  `json:"delete_mode"`
+	LastError  *string `json:"last_error,omitempty"`
+}
+
+func newProtectedResourceResponse(resource storage.ManagedResource) protectedResourceResponse {
+	return protectedResourceResponse{
+		Address:    resource.Address,
+		Kind:       resource.Kind,
+		NomadID:    nullableString(resource.NomadID),
+		Namespace:  nullableString(resource.Namespace),
+		Status:     resource.Status,
+		DeleteMode: resource.DeleteMode,
+		LastError:  nullableString(resource.LastError),
+	}
+}
+
 func newRepositoryJobResponse(file storage.RepoFile) repositoryJobResponse {
 	return repositoryJobResponse{
 		Path:       file.Path,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"io"
 	"io/fs"
 	"log/slog"
@@ -41,6 +42,9 @@ type credentialStore interface {
 type reconcileManager interface {
 	ReconcileRepo(ctx context.Context, repoID int64) error
 	PlanRepo(ctx context.Context, repoID int64) (*plan.Report, error)
+	ListProtectedResources(ctx context.Context, repoID int64) ([]storage.ManagedResource, error)
+	ForgetProtectedResource(ctx context.Context, repoID int64, address string) error
+	DeleteProtectedResource(ctx context.Context, repoID int64, address string) error
 	DeleteRepository(ctx context.Context, repoID int64, unschedule bool) error
 	DeleteCredential(ctx context.Context, credentialID int64, deleteRepos bool, unschedule bool) error
 }
@@ -88,6 +92,9 @@ func (s *Server) Handler() http.Handler {
 		api.Post("/repos", s.handleCreateRepo)
 		api.Post("/repos/{id}/reconcile", s.handleTriggerRepo)
 		api.Get("/repos/{id}/plan", s.handlePlanRepo)
+		api.Get("/repos/{id}/orphans", s.handleListOrphans)
+		api.Post("/repos/{id}/orphans/forget", s.handleForgetOrphan)
+		api.Post("/repos/{id}/orphans/delete", s.handleDeleteOrphan)
 		api.Delete("/repos/{id}", s.handleDeleteRepo)
 
 		api.Get("/credentials", s.handleListCredentials)
@@ -179,6 +186,55 @@ func (s *Server) handlePlanRepo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	respondJSON(w, result)
+}
+
+func (s *Server) handleListOrphans(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil {
+		respondStatus(w, http.StatusBadRequest, err)
+		return
+	}
+	resources, err := s.reconciler.ListProtectedResources(r.Context(), id)
+	if err != nil {
+		respondErr(w, err)
+		return
+	}
+	result := make([]protectedResourceResponse, 0, len(resources))
+	for _, resource := range resources {
+		result = append(result, newProtectedResourceResponse(resource))
+	}
+	respondJSON(w, result)
+}
+
+func (s *Server) handleForgetOrphan(w http.ResponseWriter, r *http.Request) {
+	s.handleOrphanAction(w, r, false)
+}
+
+func (s *Server) handleDeleteOrphan(w http.ResponseWriter, r *http.Request) {
+	s.handleOrphanAction(w, r, true)
+}
+
+func (s *Server) handleOrphanAction(w http.ResponseWriter, r *http.Request, deleteNomad bool) {
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil {
+		respondStatus(w, http.StatusBadRequest, err)
+		return
+	}
+	var req orphanActionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || strings.TrimSpace(req.Address) == "" {
+		respondStatus(w, http.StatusBadRequest, errors.New("resource address is required"))
+		return
+	}
+	if deleteNomad {
+		err = s.reconciler.DeleteProtectedResource(r.Context(), id, req.Address)
+	} else {
+		err = s.reconciler.ForgetProtectedResource(r.Context(), id, req.Address)
+	}
+	if err != nil {
+		respondErr(w, err)
+		return
+	}
+	respondStatus(w, http.StatusOK, nil)
 }
 
 func (s *Server) handleDeleteRepo(w http.ResponseWriter, r *http.Request) {
@@ -303,6 +359,10 @@ type createCredentialRequest struct {
 
 type deleteRepoRequest struct {
 	Unschedule bool `json:"unschedule"`
+}
+
+type orphanActionRequest struct {
+	Address string `json:"address"`
 }
 
 type deleteCredentialRequest struct {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -165,6 +165,23 @@ func (s *Server) handleTriggerRepo(w http.ResponseWriter, r *http.Request) {
 		respondStatus(w, http.StatusBadRequest, err)
 		return
 	}
+	var req reconcileRequest
+	if r.Body != nil {
+		defer r.Body.Close()
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err != io.EOF {
+			respondStatus(w, http.StatusBadRequest, err)
+			return
+		}
+	}
+	if req.DryRun {
+		result, err := s.reconciler.PlanRepo(r.Context(), id)
+		if err != nil {
+			respondErr(w, err)
+			return
+		}
+		respondJSON(w, result)
+		return
+	}
 	if err := s.reconciler.ReconcileRepo(r.Context(), id); err != nil {
 		respondErr(w, err)
 		return
@@ -358,6 +375,10 @@ func jobURL(base string, namespace string, jobID string) string {
 	}
 	jobRef := jobID + "@" + namespace
 	return trimmed + "/ui/jobs/" + url.PathEscape(jobRef)
+}
+
+type reconcileRequest struct {
+	DryRun bool `json:"dry_run"`
 }
 
 type createRepoRequest struct {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -45,6 +45,7 @@ type reconcileManager interface {
 	ListProtectedResources(ctx context.Context, repoID int64) ([]storage.ManagedResource, error)
 	ForgetProtectedResource(ctx context.Context, repoID int64, address string) error
 	DeleteProtectedResource(ctx context.Context, repoID int64, address string) error
+	AdoptBundleResource(ctx context.Context, repoID int64, address string) error
 	DeleteRepository(ctx context.Context, repoID int64, unschedule bool) error
 	DeleteCredential(ctx context.Context, credentialID int64, deleteRepos bool, unschedule bool) error
 }
@@ -95,6 +96,7 @@ func (s *Server) Handler() http.Handler {
 		api.Get("/repos/{id}/orphans", s.handleListOrphans)
 		api.Post("/repos/{id}/orphans/forget", s.handleForgetOrphan)
 		api.Post("/repos/{id}/orphans/delete", s.handleDeleteOrphan)
+		api.Post("/repos/{id}/adopt", s.handleAdoptResource)
 		api.Delete("/repos/{id}", s.handleDeleteRepo)
 
 		api.Get("/credentials", s.handleListCredentials)
@@ -231,6 +233,24 @@ func (s *Server) handleOrphanAction(w http.ResponseWriter, r *http.Request, dele
 		err = s.reconciler.ForgetProtectedResource(r.Context(), id, req.Address)
 	}
 	if err != nil {
+		respondErr(w, err)
+		return
+	}
+	respondStatus(w, http.StatusOK, nil)
+}
+
+func (s *Server) handleAdoptResource(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil {
+		respondStatus(w, http.StatusBadRequest, err)
+		return
+	}
+	var req orphanActionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || strings.TrimSpace(req.Address) == "" {
+		respondStatus(w, http.StatusBadRequest, errors.New("resource address is required"))
+		return
+	}
+	if err := s.reconciler.AdoptBundleResource(r.Context(), id, req.Address); err != nil {
 		respondErr(w, err)
 		return
 	}

--- a/internal/storage/resources.go
+++ b/internal/storage/resources.go
@@ -91,7 +91,6 @@ func (s *ManagedResourceStore) ListByRepo(ctx context.Context, repoID int64) ([]
 		var resource ManagedResource
 		var sourcePath sql.NullString
 		var resourceDependsOn sql.NullString
-		var sourcePath sql.NullString
 		if err := rows.Scan(
 			&resource.ID,
 			&resource.RepoID,

--- a/internal/storage/resources.go
+++ b/internal/storage/resources.go
@@ -91,6 +91,7 @@ func (s *ManagedResourceStore) ListByRepo(ctx context.Context, repoID int64) ([]
 		var resource ManagedResource
 		var sourcePath sql.NullString
 		var resourceDependsOn sql.NullString
+		var sourcePath sql.NullString
 		if err := rows.Scan(
 			&resource.ID,
 			&resource.RepoID,


### PR DESCRIPTION
## Summary
Adds unmanaged-resource conflict reporting, explicit adoption, protected orphan handling, and lifecycle commands for safe cleanup.

## Review focus
- Ownership and collision rules
- Adoption safeguards
- Protected deletion and orphan state transitions

## Stack
Builds on #20.

## Validation
`go test ./...`