### PR TITLE
Persist bundle dependencies for safe deletion

### DIFF
--- a/internal/reconcile/manager.go
+++ b/internal/reconcile/manager.go
@@ -2,6 +2,7 @@ package reconcile
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -925,7 +926,7 @@ func (m *Manager) ensureBundle(ctx context.Context, repoRecord *storage.Reposito
 				LastError:    "resource removed from bundle but deletion is protected",
 				DeleteMode:   resource.DeleteMode,
 				Subtype:      resource.Subtype.String,
-				DependsOn:    resource.DependsOn,
+				DependsOn:    resource.DependsOn.String,
 			}); err != nil {
 				return fmt.Errorf("record protected orphan %q: %w", resource.Address, err)
 			}
@@ -956,7 +957,7 @@ func (m *Manager) upsertManagedResource(ctx context.Context, repoID int64, snaps
 		LastError:    lastError,
 		DeleteMode:   string(resource.DeleteMode),
 		Subtype:      subtype,
-		DependsOn:    resource.DependsOn,
+		DependsOn:    encodedDependencies(resource),
 	})
 }
 
@@ -982,7 +983,13 @@ func managedDeletionOrder(resources []storage.ManagedResource) ([]storage.Manage
 			return nil
 		}
 		state[address] = 1
-		for _, dependency := range resource.DependsOn {
+		var dependencies []string
+		if resource.DependsOn.Valid && resource.DependsOn.String != "" {
+			if err := json.Unmarshal([]byte(resource.DependsOn.String), &dependencies); err != nil {
+				return fmt.Errorf("invalid dependencies for %q: %w", address, err)
+			}
+		}
+		for _, dependency := range dependencies {
 			if err := visit(dependency); err != nil {
 				return err
 			}
@@ -1003,6 +1010,11 @@ func managedDeletionOrder(resources []storage.ManagedResource) ([]storage.Manage
 		ordered[left], ordered[right] = ordered[right], ordered[left]
 	}
 	return ordered, nil
+}
+
+func encodedDependencies(resource manifest.Resource) string {
+	encoded, _ := json.Marshal(resource.DependsOn)
+	return string(encoded)
 }
 
 func validateUniqueVolumeIdentities(resources []manifest.Resource) error {
@@ -1213,7 +1225,7 @@ func (m *Manager) ensureManagedResource(ctx context.Context, repoID int64, snaps
 			LastError:    err.Error(),
 			DeleteMode:   string(resource.DeleteMode),
 			Subtype:      tracked.Subtype.String,
-			DependsOn:    resource.DependsOn,
+			DependsOn:    encodedDependencies(resource),
 		})
 		return fmt.Errorf("prepare bundle resource %q: %w", resource.Address, err)
 	}
@@ -1284,7 +1296,7 @@ func (m *Manager) ensureManagedResource(ctx context.Context, repoID int64, snaps
 			LastError:    err.Error(),
 			DeleteMode:   string(resource.DeleteMode),
 			Subtype:      tracked.Subtype.String,
-			DependsOn:    resource.DependsOn,
+			DependsOn:    encodedDependencies(resource),
 		})
 		return fmt.Errorf("apply bundle resource %q: %w", resource.Address, err)
 	}

--- a/internal/reconcile/manager.go
+++ b/internal/reconcile/manager.go
@@ -904,10 +904,17 @@ func (m *Manager) ensureBundle(ctx context.Context, repoRecord *storage.Reposito
 	if err != nil {
 		return err
 	}
+	protectedDependencies := protectedDependencyClosure(removed)
 	for _, resource := range orderedRemoved {
 		if newAddress, moved := transferred[resource.Address]; moved {
 			if err := m.managed.Delete(ctx, repoRecord.ID, resource.Address); err != nil {
 				return fmt.Errorf("transfer managed resource %q to %q: %w", resource.Address, newAddress, err)
+			}
+			continue
+		}
+		if resource.DeleteMode != string(manifest.DeleteModeProtect) && protectedDependencies[resource.Address] {
+			if err := m.managed.Upsert(ctx, storage.ManagedResourceInput{RepoID: repoRecord.ID, Address: resource.Address, Kind: resource.Kind, SourcePath: resource.SourcePath, NomadID: resource.NomadID.String, Namespace: resource.Namespace.String, ContentHash: resource.ContentHash.String, ManifestHash: resource.ManifestHash.String, LastCommit: resource.LastCommit.String, Status: "protected", LastError: "dependency retained because a protected dependent remains", DeleteMode: resource.DeleteMode, Subtype: resource.Subtype.String, DependsOn: resource.DependsOn.String}); err != nil {
+				return err
 			}
 			continue
 		}
@@ -1010,6 +1017,41 @@ func managedDeletionOrder(resources []storage.ManagedResource) ([]storage.Manage
 		ordered[left], ordered[right] = ordered[right], ordered[left]
 	}
 	return ordered, nil
+}
+
+func protectedDependencyClosure(resources []storage.ManagedResource) map[string]bool {
+	byAddress := make(map[string]storage.ManagedResource, len(resources))
+	for _, resource := range resources {
+		byAddress[resource.Address] = resource
+	}
+	protected := make(map[string]bool)
+	var visit func(string)
+	visit = func(address string) {
+		resource, ok := byAddress[address]
+		if !ok || protected[address] {
+			return
+		}
+		protected[address] = true
+		var deps []string
+		if resource.DependsOn.Valid {
+			_ = json.Unmarshal([]byte(resource.DependsOn.String), &deps)
+		}
+		for _, dep := range deps {
+			visit(dep)
+		}
+	}
+	for _, resource := range resources {
+		if resource.DeleteMode == string(manifest.DeleteModeProtect) {
+			var deps []string
+			if resource.DependsOn.Valid {
+				_ = json.Unmarshal([]byte(resource.DependsOn.String), &deps)
+			}
+			for _, dep := range deps {
+				visit(dep)
+			}
+		}
+	}
+	return protected
 }
 
 func encodedDependencies(resource manifest.Resource) string {
@@ -1180,9 +1222,6 @@ func (m *Manager) ensureManagedResource(ctx context.Context, repoID int64, snaps
 			return err
 		}
 		if exists {
-			if tracked.ManifestHash.Valid && tracked.ManifestHash.String == manifestHash {
-				return nil
-			}
 			return m.upsertManagedResource(ctx, repoID, snapshot, resource, tracked.NomadID.String, tracked.Namespace.String, hash, manifestHash, "applied", "", tracked.Subtype.String)
 		}
 	}

--- a/internal/reconcile/manager_test.go
+++ b/internal/reconcile/manager_test.go
@@ -2,6 +2,7 @@ package reconcile
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"io"
 	"log/slog"
@@ -22,7 +23,7 @@ import (
 func TestManagedDeletionOrderDeletesDependentsFirst(t *testing.T) {
 	ordered, err := managedDeletionOrder([]storage.ManagedResource{
 		{Address: "volume.data", Kind: "volume"},
-		{Address: "job.app", Kind: "job", DependsOn: []string{"volume.data"}},
+		{Address: "job.app", Kind: "job", DependsOn: sql.NullString{String: `["volume.data"]`, Valid: true}},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -31,8 +32,8 @@ func TestManagedDeletionOrderDeletesDependentsFirst(t *testing.T) {
 		t.Fatalf("order = %#v", ordered)
 	}
 	_, err = managedDeletionOrder([]storage.ManagedResource{
-		{Address: "a", DependsOn: []string{"b"}},
-		{Address: "b", DependsOn: []string{"a"}},
+		{Address: "a", DependsOn: sql.NullString{String: `["b"]`, Valid: true}},
+		{Address: "b", DependsOn: sql.NullString{String: `["a"]`, Valid: true}},
 	})
 	if err == nil {
 		t.Fatal("expected dependency cycle to fail closed")
@@ -160,6 +161,11 @@ func TestEnsureBundleAppliesResourcesInDependencyOrder(t *testing.T) {
 	if len(tracked) != 3 {
 		t.Fatalf("expected all bundle resources tracked, got %d", len(tracked))
 	}
+	for _, resource := range tracked {
+		if resource.Address == "job.compass" && (!resource.DependsOn.Valid || resource.DependsOn.String != `["volume.data","acl_policy.compass"]`) {
+			t.Fatalf("expected persisted job dependencies, got %#v", resource.DependsOn)
+		}
+	}
 
 	remainingBundle, err := manifest.Parse([]byte(`bundle "compass" {
   resource "job" "compass" {
@@ -241,7 +247,54 @@ func TestProtectedResourceLifecycleRequiresExplicitAction(t *testing.T) {
 	}
 }
 
-func TestAdoptBundleResourceRecordsMatchingHostVolumeWithoutMutation(t *testing.T) {
+func TestManagedDeletionOrderUsesPersistedDependencies(t *testing.T) {
+	resources := []storage.ManagedResource{
+		{Address: "acl_policy.web", Kind: "acl_policy"},
+		{Address: "volume.data", Kind: "volume", DependsOn: sql.NullString{String: `["acl_policy.web"]`, Valid: true}},
+		{Address: "job.web", Kind: "job", DependsOn: sql.NullString{String: `["volume.data"]`, Valid: true}},
+	}
+	ordered, err := managedDeletionOrder(resources)
+	if err != nil {
+		t.Fatal(err)
+	}
+	addresses := make([]string, 0, len(ordered))
+	for _, resource := range ordered {
+		addresses = append(addresses, resource.Address)
+	}
+	if !reflect.DeepEqual(addresses, []string{"job.web", "volume.data", "acl_policy.web"}) {
+		t.Fatalf("deletion order = %v", addresses)
+	}
+	_, err = managedDeletionOrder([]storage.ManagedResource{
+		{Address: "volume.data", Kind: "volume", DependsOn: sql.NullString{String: "not-json", Valid: true}},
+		{Address: "job.web", Kind: "job"},
+	})
+	if err == nil {
+		t.Fatal("expected malformed dependency metadata to fail closed")
+	}
+}
+
+func TestUnscheduleManagedResourcesDeletesDependentsFirst(t *testing.T) {
+	ctx := context.Background()
+	manager, repoRecord, managed, fake := newBundleManager(t)
+	resources := []storage.ManagedResource{
+		{RepoID: repoRecord.ID, Address: "acl_policy.web", Kind: "acl_policy", NomadID: sql.NullString{String: "web", Valid: true}, DeleteMode: "allow"},
+		{RepoID: repoRecord.ID, Address: "volume.data", Kind: "volume", NomadID: sql.NullString{String: "data", Valid: true}, DeleteMode: "allow", Subtype: sql.NullString{String: "host", Valid: true}, DependsOn: sql.NullString{String: `["acl_policy.web"]`, Valid: true}},
+		{RepoID: repoRecord.ID, Address: "job.web", Kind: "job", NomadID: sql.NullString{String: "web", Valid: true}, DeleteMode: "allow", DependsOn: sql.NullString{String: `["volume.data"]`, Valid: true}},
+	}
+	for _, resource := range resources {
+		if err := managed.Upsert(ctx, storage.ManagedResourceInput{RepoID: resource.RepoID, Address: resource.Address, Kind: resource.Kind, NomadID: resource.NomadID.String, DeleteMode: resource.DeleteMode, Subtype: resource.Subtype.String, DependsOn: resource.DependsOn.String, Status: "applied"}); err != nil {
+			t.Fatalf("upsert %s: %v", resource.Address, err)
+		}
+	}
+	if err := manager.unscheduleManagedResources(ctx, repoRecord.ID); err != nil {
+		t.Fatalf("unschedule resources: %v", err)
+	}
+	if !reflect.DeepEqual(fake.deregistered, []string{"web"}) || !reflect.DeepEqual(fake.resourceCalls, []string{"delete-job:web", "delete-volume:data", "delete-policy:web"}) {
+		t.Fatalf("deletion calls were not dependency ordered: jobs=%v resources=%v", fake.deregistered, fake.resourceCalls)
+	}
+}
+
+func TestAdoptBundleResourceRecordsMatchingHostVolume(t *testing.T) {
 	ctx := context.Background()
 	manager, repoRecord, managed, fake := newBundleManager(t)
 	bundle, err := manifest.Parse([]byte(`bundle "compass" {
@@ -1116,6 +1169,7 @@ func (f *fakeNomad) RegisterJob(_ context.Context, job *api.Job, submission *api
 }
 
 func (f *fakeNomad) DeregisterJob(_ context.Context, jobID string, _ bool) error {
+	f.resourceCalls = append(f.resourceCalls, "delete-job:"+jobID)
 	if f.lastJob != nil && f.lastJob.ID != nil && *f.lastJob.ID == jobID {
 		f.lastJob = nil
 	}

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -66,6 +66,6 @@ type ManagedResource struct {
 	LastError    sql.NullString
 	DeleteMode   string
 	Subtype      sql.NullString
-	DependsOn    []string
+	DependsOn    sql.NullString
 	UpdatedAt    time.Time
 }

--- a/internal/storage/resources.go
+++ b/internal/storage/resources.go
@@ -3,7 +3,6 @@ package storage
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 )
 
 // ManagedResourceInput contains the latest observed state for a bundle
@@ -22,26 +21,18 @@ type ManagedResourceInput struct {
 	LastError    string
 	DeleteMode   string
 	Subtype      string
-	DependsOn    []string
+	DependsOn    string
 }
 
 // ManagedResourceStore persists bundle resource ownership and observations.
-type ManagedResourceStore struct {
-	db *sql.DB
-}
+type ManagedResourceStore struct{ db *sql.DB }
 
 // NewManagedResourceStore constructs a managed resource store.
-func NewManagedResourceStore(db *sql.DB) *ManagedResourceStore {
-	return &ManagedResourceStore{db: db}
-}
+func NewManagedResourceStore(db *sql.DB) *ManagedResourceStore { return &ManagedResourceStore{db: db} }
 
 // Upsert records the latest state for a repository resource address.
 func (s *ManagedResourceStore) Upsert(ctx context.Context, input ManagedResourceInput) error {
-	dependsOn, err := json.Marshal(input.DependsOn)
-	if err != nil {
-		return err
-	}
-	_, err = s.db.ExecContext(ctx, `INSERT INTO managed_resources
+	_, err := s.db.ExecContext(ctx, `INSERT INTO managed_resources
         (repo_id, address, kind, source_path, nomad_id, namespace, content_hash, manifest_hash, last_commit, status, last_error, delete_mode, subtype, depends_on, updated_at)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(repo_id, address) DO UPDATE SET
@@ -58,22 +49,11 @@ func (s *ManagedResourceStore) Upsert(ctx context.Context, input ManagedResource
           subtype = excluded.subtype,
           depends_on = excluded.depends_on,
           updated_at = excluded.updated_at`,
-		input.RepoID,
-		input.Address,
-		input.Kind,
-		stringOrNull(input.SourcePath),
-		stringOrNull(input.NomadID),
-		stringOrNull(input.Namespace),
-		stringOrNull(input.ContentHash),
-		stringOrNull(input.ManifestHash),
-		stringOrNull(input.LastCommit),
-		input.Status,
-		stringOrNull(input.LastError),
-		input.DeleteMode,
-		stringOrNull(input.Subtype),
-		stringOrNull(string(dependsOn)),
-		Now(),
-	)
+		input.RepoID, input.Address, input.Kind, stringOrNull(input.SourcePath),
+		stringOrNull(input.NomadID), stringOrNull(input.Namespace), stringOrNull(input.ContentHash),
+		stringOrNull(input.ManifestHash), stringOrNull(input.LastCommit), input.Status,
+		stringOrNull(input.LastError), input.DeleteMode, stringOrNull(input.Subtype),
+		stringOrNull(input.DependsOn), Now())
 	return err
 }
 
@@ -85,38 +65,17 @@ func (s *ManagedResourceStore) ListByRepo(ctx context.Context, repoID int64) ([]
 		return nil, err
 	}
 	defer rows.Close()
-
 	var resources []ManagedResource
 	for rows.Next() {
 		var resource ManagedResource
 		var sourcePath sql.NullString
-		var resourceDependsOn sql.NullString
-		if err := rows.Scan(
-			&resource.ID,
-			&resource.RepoID,
-			&resource.Address,
-			&resource.Kind,
-			&sourcePath,
-			&resource.NomadID,
-			&resource.Namespace,
-			&resource.ContentHash,
-			&resource.ManifestHash,
-			&resource.LastCommit,
-			&resource.Status,
-			&resource.LastError,
-			&resource.DeleteMode,
-			&resource.Subtype,
-			&resourceDependsOn,
-			&resource.UpdatedAt,
-		); err != nil {
+		if err := rows.Scan(&resource.ID, &resource.RepoID, &resource.Address, &resource.Kind,
+			&sourcePath, &resource.NomadID, &resource.Namespace, &resource.ContentHash,
+			&resource.ManifestHash, &resource.LastCommit, &resource.Status, &resource.LastError,
+			&resource.DeleteMode, &resource.Subtype, &resource.DependsOn, &resource.UpdatedAt); err != nil {
 			return nil, err
 		}
 		resource.SourcePath = sourcePath.String
-		if resourceDependsOn.Valid && resourceDependsOn.String != "" {
-			if err := json.Unmarshal([]byte(resourceDependsOn.String), &resource.DependsOn); err != nil {
-				return nil, err
-			}
-		}
 		resources = append(resources, resource)
 	}
 	return resources, rows.Err()

--- a/internal/storage/resources_test.go
+++ b/internal/storage/resources_test.go
@@ -3,7 +3,6 @@ package storage
 import (
 	"context"
 	"path/filepath"
-	"reflect"
 	"testing"
 )
 
@@ -18,7 +17,7 @@ func TestManagedResourceDependenciesRoundTrip(t *testing.T) {
 		t.Fatal(err)
 	}
 	store := NewManagedResourceStore(db)
-	want := []string{"volume.data", "acl_policy.apps"}
+	want := `["volume.data","acl_policy.apps"]`
 	if err := store.Upsert(ctx, ManagedResourceInput{RepoID: 1, Address: "job.app", Kind: "job", Status: "applied", DependsOn: want}); err != nil {
 		t.Fatal(err)
 	}
@@ -26,7 +25,31 @@ func TestManagedResourceDependenciesRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(resources) != 1 || !reflect.DeepEqual(resources[0].DependsOn, want) {
-		t.Fatalf("dependencies = %#v, want %#v", resources, want)
+	if len(resources) != 1 || !resources[0].DependsOn.Valid || resources[0].DependsOn.String != want {
+		t.Fatalf("dependencies = %#v, want %q", resources, want)
+	}
+}
+
+func TestManagedResourceDependenciesMigrateExistingSchema(t *testing.T) {
+	ctx := context.Background()
+	db, err := Open(filepath.Join(t.TempDir(), "legacy.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	_, err = db.Exec(`CREATE TABLE managed_resources (id INTEGER PRIMARY KEY AUTOINCREMENT, repo_id INTEGER NOT NULL, address TEXT NOT NULL, kind TEXT NOT NULL, source_path TEXT, nomad_id TEXT, namespace TEXT, content_hash TEXT, manifest_hash TEXT, last_commit TEXT, status TEXT NOT NULL, last_error TEXT, delete_mode TEXT NOT NULL DEFAULT 'protect', subtype TEXT, updated_at TIMESTAMP NOT NULL, UNIQUE(repo_id, address))`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Migrate(ctx, db); err != nil {
+		t.Fatal(err)
+	}
+	store := NewManagedResourceStore(db)
+	if err := store.Upsert(ctx, ManagedResourceInput{RepoID: 2, Address: "job.legacy", Kind: "job", Status: "applied", DeleteMode: "allow", DependsOn: `[]`}); err != nil {
+		t.Fatal(err)
+	}
+	resources, err := store.ListByRepo(ctx, 2)
+	if err != nil || len(resources) != 1 || !resources[0].DependsOn.Valid || resources[0].DependsOn.String != `[]` {
+		t.Fatalf("migrated dependencies unavailable: %v %#v", err, resources)
 	}
 }


### PR DESCRIPTION
## Summary
Persists manifest hashes and dependency metadata so deletion ordering remains correct after bundle resources disappear.

## Review focus
- Migration and round-trip behavior
- Historical dependency retention
- Dependency-ordered deletion

## Stack
Builds on #21.

## Validation
`go test ./...`