### PR TITLE
Add per-kind Nomad resource adapters

### DIFF
--- a/internal/manifest/nomad.go
+++ b/internal/manifest/nomad.go
@@ -342,6 +342,183 @@ func stringMap(value interface{}) (map[string]string, error) {
 	return result, nil
 }
 
+// CompileNamespace decodes a native Nomad namespace body.
+func CompileNamespace(resource Resource) (*api.Namespace, error) {
+	if resource.Kind != "namespace" {
+		return nil, fmt.Errorf("resource %q is not a namespace", resource.Address)
+	}
+	values, err := decodeNativeValues(resource, map[string]struct{}{
+		"description": {}, "quota": {}, "capabilities": {}, "node_pool_config": {}, "vault": {}, "consul": {}, "meta": {},
+	})
+	if err != nil {
+		return nil, err
+	}
+	namespace := &api.Namespace{Name: resource.Name}
+	if err := strictDecode(values, namespace); err != nil {
+		return nil, fmt.Errorf("decode namespace %q: %w", resource.Address, err)
+	}
+	return namespace, nil
+}
+
+// CompileQuota decodes a native Nomad quota body.
+func CompileQuota(resource Resource) (*api.QuotaSpec, error) {
+	if resource.Kind != "quota" {
+		return nil, fmt.Errorf("resource %q is not a quota", resource.Address)
+	}
+	values, err := decodeNativeValues(resource, map[string]struct{}{"description": {}, "limit": {}})
+	if err != nil {
+		return nil, err
+	}
+	quota := &api.QuotaSpec{Name: resource.Name}
+	delete(values, "limit")
+	if err := strictDecode(values, quota); err != nil {
+		return nil, fmt.Errorf("decode quota %q: %w", resource.Address, err)
+	}
+	file, err := oldhcl.Parse(string(resource.Body))
+	if err != nil {
+		return nil, fmt.Errorf("parse quota %q: %w", resource.Address, err)
+	}
+	list, ok := file.Node.(*ast.ObjectList)
+	if !ok {
+		return nil, fmt.Errorf("quota %q body must be an object", resource.Address)
+	}
+	for _, item := range list.Filter("limit").Elem().Items {
+		limitValues := map[string]interface{}{}
+		if err := oldhcl.DecodeObject(&limitValues, item.Val); err != nil {
+			return nil, fmt.Errorf("decode quota %q limit: %w", resource.Address, err)
+		}
+		var regionLimit *api.QuotaResources
+		if nested, ok := item.Val.(*ast.ObjectList); ok {
+			for _, regionItem := range nested.Filter("region_limit").Elem().Items {
+				regionValues := map[string]interface{}{}
+				if err := oldhcl.DecodeObject(&regionValues, regionItem.Val); err != nil {
+					return nil, fmt.Errorf("decode quota %q region limit: %w", resource.Address, err)
+				}
+				regionLimit = &api.QuotaResources{}
+				if err := strictDecode(regionValues, regionLimit); err != nil {
+					return nil, fmt.Errorf("decode quota %q region limit: %w", resource.Address, err)
+				}
+				break
+			}
+		}
+		delete(limitValues, "region_limit")
+		var input struct {
+			Region         string `mapstructure:"region"`
+			VariablesLimit *int   `mapstructure:"variables_limit"`
+		}
+		if err := strictDecode(limitValues, &input); err != nil {
+			return nil, fmt.Errorf("decode quota %q limit: %w", resource.Address, err)
+		}
+		quota.Limits = append(quota.Limits, &api.QuotaLimit{Region: input.Region, RegionLimit: regionLimit, VariablesLimit: input.VariablesLimit})
+	}
+	if len(quota.Limits) == 0 {
+		return nil, fmt.Errorf("quota %q must contain a limit block", resource.Address)
+	}
+	return quota, nil
+}
+
+// CompileVariable decodes a native Nomad variable body. The resource name is
+// the default path, allowing the Compass address to remain stable if the body
+// is moved between files.
+func CompileVariable(resource Resource) (*api.Variable, error) {
+	if resource.Kind != "variable" {
+		return nil, fmt.Errorf("resource %q is not a variable", resource.Address)
+	}
+	values, err := decodeNativeValues(resource, map[string]struct{}{"namespace": {}, "path": {}, "items": {}})
+	if err != nil {
+		return nil, err
+	}
+	variable := &api.Variable{Path: resource.Name}
+	if err := strictDecode(values, variable); err != nil {
+		return nil, fmt.Errorf("decode variable %q: %w", resource.Address, err)
+	}
+	if variable.Path == "" {
+		variable.Path = resource.Name
+	}
+	if len(variable.Items) == 0 {
+		return nil, fmt.Errorf("variable %q must contain items", resource.Address)
+	}
+	return variable, nil
+}
+
+func strictDecode(values map[string]interface{}, target interface{}) error {
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{Result: target, TagName: "mapstructure", ErrorUnused: true, WeaklyTypedInput: true})
+	if err != nil {
+		return err
+	}
+	return decoder.Decode(values)
+}
+
+func decodeNativeValues(resource Resource, allowed map[string]struct{}) (map[string]interface{}, error) {
+	file, err := oldhcl.Parse(string(resource.Body))
+	if err != nil {
+		return nil, fmt.Errorf("parse %s %q: %w", resource.Kind, resource.Address, err)
+	}
+	list, ok := file.Node.(*ast.ObjectList)
+	if !ok {
+		return nil, fmt.Errorf("%s %q body must be an object", resource.Kind, resource.Address)
+	}
+	values := map[string]interface{}{}
+	if err := oldhcl.DecodeObject(&values, list); err != nil {
+		return nil, fmt.Errorf("decode %s %q: %w", resource.Kind, resource.Address, err)
+	}
+	for name := range values {
+		if _, ok := allowed[name]; !ok {
+			return nil, fmt.Errorf("%s %q has unsupported attribute or block %q", resource.Kind, resource.Address, name)
+		}
+	}
+	return values, nil
+}
+
+// CompileSentinelPolicy decodes a native Nomad Sentinel policy body.
+func CompileSentinelPolicy(resource Resource) (*api.SentinelPolicy, error) {
+	if resource.Kind != "sentinel_policy" {
+		return nil, fmt.Errorf("resource %q is not a Sentinel policy", resource.Address)
+	}
+	file, diags := hclwrite.ParseConfig(resource.Body, resource.SourcePath, hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return nil, fmt.Errorf("parse Sentinel policy %q: %s", resource.Address, diags.Error())
+	}
+	body := file.Body()
+	allowed := map[string]struct{}{"description": {}, "scope": {}, "enforcement_level": {}, "policy": {}}
+	for name := range body.Attributes() {
+		if _, ok := allowed[name]; !ok {
+			return nil, fmt.Errorf("Sentinel policy %q has unsupported attribute %q", resource.Address, name)
+		}
+	}
+	read := func(name string, required bool) (string, error) {
+		attr := body.GetAttribute(name)
+		if attr == nil {
+			if required {
+				return "", fmt.Errorf("Sentinel policy %q must define %s", resource.Address, name)
+			}
+			return "", nil
+		}
+		value, err := stringAttribute(attr, resource.SourcePath)
+		if err != nil {
+			return "", fmt.Errorf("Sentinel policy %q %s: %w", resource.Address, name, err)
+		}
+		return value, nil
+	}
+	description, err := read("description", false)
+	if err != nil {
+		return nil, err
+	}
+	scope, err := read("scope", true)
+	if err != nil {
+		return nil, err
+	}
+	enforcement, err := read("enforcement_level", true)
+	if err != nil {
+		return nil, err
+	}
+	policy, err := read("policy", true)
+	if err != nil {
+		return nil, err
+	}
+	return &api.SentinelPolicy{Name: resource.Name, Description: description, Scope: scope, EnforcementLevel: enforcement, Policy: policy}, nil
+}
+
 // CompileACLPolicy converts an embedded policy rules block into the raw HCL
 // string required by Nomad's ACL policy API.
 func CompileACLPolicy(resource Resource) (*api.ACLPolicy, error) {

--- a/internal/manifest/nomad.go
+++ b/internal/manifest/nomad.go
@@ -435,6 +435,9 @@ func CompileVariable(resource Resource) (*api.Variable, error) {
 	if variable.Path == "" {
 		variable.Path = resource.Name
 	}
+	if variable.Namespace == "" {
+		variable.Namespace = "default"
+	}
 	if len(variable.Items) == 0 {
 		return nil, fmt.Errorf("variable %q must contain items", resource.Address)
 	}
@@ -481,6 +484,9 @@ func CompileSentinelPolicy(resource Resource) (*api.SentinelPolicy, error) {
 	}
 	body := file.Body()
 	allowed := map[string]struct{}{"description": {}, "scope": {}, "enforcement_level": {}, "policy": {}}
+	for _, block := range body.Blocks() {
+		return nil, fmt.Errorf("Sentinel policy %q has unsupported block %q", resource.Address, block.Type())
+	}
 	for name := range body.Attributes() {
 		if _, ok := allowed[name]; !ok {
 			return nil, fmt.Errorf("Sentinel policy %q has unsupported attribute %q", resource.Address, name)

--- a/internal/nomadclient/namespace.go
+++ b/internal/nomadclient/namespace.go
@@ -1,0 +1,38 @@
+package nomadclient
+
+import (
+	"context"
+	"errors"
+
+	"github.com/hashicorp/nomad/api"
+)
+
+func (a *API) ApplyNamespace(_ context.Context, namespace *api.Namespace) error {
+	if namespace == nil || namespace.Name == "" {
+		return errors.New("namespace and name are required")
+	}
+	_, err := a.client.Namespaces().Register(namespace, nil)
+	return err
+}
+
+func (a *API) ObserveNamespace(_ context.Context, name string) (*api.Namespace, error) {
+	if name == "" {
+		return nil, nil
+	}
+	namespace, _, err := a.client.Namespaces().Info(name, nil)
+	if isNotFound(err) {
+		return nil, nil
+	}
+	return namespace, err
+}
+
+func (a *API) DeleteNamespace(_ context.Context, name string) error {
+	if name == "" {
+		return nil
+	}
+	_, err := a.client.Namespaces().Delete(name, nil)
+	if isNotFound(err) {
+		return nil
+	}
+	return err
+}

--- a/internal/nomadclient/quota.go
+++ b/internal/nomadclient/quota.go
@@ -1,0 +1,38 @@
+package nomadclient
+
+import (
+	"context"
+	"errors"
+
+	"github.com/hashicorp/nomad/api"
+)
+
+func (a *API) ApplyQuota(_ context.Context, quota *api.QuotaSpec) error {
+	if quota == nil || quota.Name == "" {
+		return errors.New("quota and name are required")
+	}
+	_, err := a.client.Quotas().Register(quota, nil)
+	return err
+}
+
+func (a *API) ObserveQuota(_ context.Context, name string) (*api.QuotaSpec, error) {
+	if name == "" {
+		return nil, nil
+	}
+	quota, _, err := a.client.Quotas().Info(name, nil)
+	if isNotFound(err) {
+		return nil, nil
+	}
+	return quota, err
+}
+
+func (a *API) DeleteQuota(_ context.Context, name string) error {
+	if name == "" {
+		return nil
+	}
+	_, err := a.client.Quotas().Delete(name, nil)
+	if isNotFound(err) {
+		return nil
+	}
+	return err
+}

--- a/internal/nomadclient/resources.go
+++ b/internal/nomadclient/resources.go
@@ -17,6 +17,10 @@ type ResourceLookup interface {
 	FindHostVolume(ctx context.Context, name, namespace string) (*api.HostVolume, error)
 	FindCSIVolume(ctx context.Context, name, namespace string) (*api.CSIVolume, error)
 	ObserveACLPolicy(ctx context.Context, name string) (*api.ACLPolicy, error)
+	ObserveNamespace(ctx context.Context, name string) (*api.Namespace, error)
+	ObserveQuota(ctx context.Context, name string) (*api.QuotaSpec, error)
+	ObserveVariable(ctx context.Context, namespace, path string) (*api.Variable, error)
+	ObserveSentinelPolicy(ctx context.Context, name string) (*api.SentinelPolicy, error)
 }
 
 type ResourceClient interface {
@@ -30,6 +34,18 @@ type ResourceClient interface {
 	ApplyACLPolicy(ctx context.Context, policy *api.ACLPolicy) error
 	ObserveACLPolicy(ctx context.Context, name string) (*api.ACLPolicy, error)
 	DeleteACLPolicy(ctx context.Context, name string) error
+	ObserveNamespace(ctx context.Context, name string) (*api.Namespace, error)
+	ObserveQuota(ctx context.Context, name string) (*api.QuotaSpec, error)
+	ObserveVariable(ctx context.Context, namespace, path string) (*api.Variable, error)
+	ObserveSentinelPolicy(ctx context.Context, name string) (*api.SentinelPolicy, error)
+	ApplyNamespace(ctx context.Context, namespace *api.Namespace) error
+	DeleteNamespace(ctx context.Context, name string) error
+	ApplyQuota(ctx context.Context, quota *api.QuotaSpec) error
+	DeleteQuota(ctx context.Context, name string) error
+	ApplyVariable(ctx context.Context, variable *api.Variable) (*api.Variable, error)
+	DeleteVariable(ctx context.Context, namespace, path string) error
+	ApplySentinelPolicy(ctx context.Context, policy *api.SentinelPolicy) error
+	DeleteSentinelPolicy(ctx context.Context, name string) error
 }
 
 func (a *API) ApplyHostVolume(_ context.Context, volume *api.HostVolume) (*api.HostVolume, error) {

--- a/internal/nomadclient/sentinel.go
+++ b/internal/nomadclient/sentinel.go
@@ -1,0 +1,38 @@
+package nomadclient
+
+import (
+	"context"
+	"errors"
+
+	"github.com/hashicorp/nomad/api"
+)
+
+func (a *API) ApplySentinelPolicy(_ context.Context, policy *api.SentinelPolicy) error {
+	if policy == nil || policy.Name == "" {
+		return errors.New("sentinel policy and name are required")
+	}
+	_, err := a.client.SentinelPolicies().Upsert(policy, nil)
+	return err
+}
+
+func (a *API) ObserveSentinelPolicy(_ context.Context, name string) (*api.SentinelPolicy, error) {
+	if name == "" {
+		return nil, nil
+	}
+	policy, _, err := a.client.SentinelPolicies().Info(name, nil)
+	if isNotFound(err) {
+		return nil, nil
+	}
+	return policy, err
+}
+
+func (a *API) DeleteSentinelPolicy(_ context.Context, name string) error {
+	if name == "" {
+		return nil
+	}
+	_, err := a.client.SentinelPolicies().Delete(name, nil)
+	if isNotFound(err) {
+		return nil
+	}
+	return err
+}

--- a/internal/nomadclient/variable.go
+++ b/internal/nomadclient/variable.go
@@ -1,0 +1,38 @@
+package nomadclient
+
+import (
+	"context"
+	"errors"
+
+	"github.com/hashicorp/nomad/api"
+)
+
+func (a *API) ApplyVariable(_ context.Context, variable *api.Variable) (*api.Variable, error) {
+	if variable == nil || variable.Path == "" {
+		return nil, errors.New("variable and path are required")
+	}
+	result, _, err := a.client.Variables().Update(variable, nil)
+	return result, err
+}
+
+func (a *API) ObserveVariable(_ context.Context, namespace, path string) (*api.Variable, error) {
+	if path == "" {
+		return nil, nil
+	}
+	variable, _, err := a.client.Variables().Peek(path, &api.QueryOptions{Namespace: namespace})
+	if isNotFound(err) || errors.Is(err, api.ErrVariablePathNotFound) {
+		return nil, nil
+	}
+	return variable, err
+}
+
+func (a *API) DeleteVariable(_ context.Context, namespace, path string) error {
+	if path == "" {
+		return nil
+	}
+	_, err := a.client.Variables().Delete(path, &api.WriteOptions{Namespace: namespace})
+	if isNotFound(err) || errors.Is(err, api.ErrVariablePathNotFound) {
+		return nil
+	}
+	return err
+}

--- a/internal/reconcile/acl_policy_adapter.go
+++ b/internal/reconcile/acl_policy_adapter.go
@@ -1,0 +1,87 @@
+package reconcile
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/brianmichel/nomad-compass/internal/manifest"
+	"github.com/brianmichel/nomad-compass/internal/nomadclient"
+	"github.com/brianmichel/nomad-compass/internal/plan"
+	"github.com/brianmichel/nomad-compass/internal/storage"
+)
+
+type aclPolicyAdapter struct{}
+
+func (aclPolicyAdapter) Kind() string { return "acl_policy" }
+
+func (aclPolicyAdapter) Validate(resource manifest.Resource) error {
+	if _, err := manifest.CompileACLPolicy(resource); err != nil {
+		return fmt.Errorf("validate bundle ACL policy %q: %w", resource.Address, err)
+	}
+	return nil
+}
+
+func (aclPolicyAdapter) Lookup(ctx context.Context, lookup nomadclient.ResourceLookup, resource manifest.Resource) (bool, error) {
+	policy, err := lookup.ObserveACLPolicy(ctx, resource.Name)
+	return policy != nil, err
+}
+
+func (aclPolicyAdapter) Observe(ctx context.Context, client nomadclient.ResourceClient, resource manifest.Resource, _ storage.ManagedResource) (plan.Observation, error) {
+	policy, err := client.ObserveACLPolicy(ctx, resource.Name)
+	if err != nil || policy == nil {
+		return plan.Observation{Present: policy != nil}, err
+	}
+	desired, err := manifest.CompileACLPolicy(resource)
+	if err != nil {
+		return plan.Observation{}, err
+	}
+	matches := policy.Description == desired.Description && strings.TrimSpace(policy.Rules) == strings.TrimSpace(desired.Rules)
+	return plan.Observation{Present: true, Matches: matches}, nil
+}
+
+func (aclPolicyAdapter) Replace(context.Context, nomadclient.ResourceClient, manifest.Resource, storage.ManagedResource) error {
+	return nil
+}
+
+func (aclPolicyAdapter) Apply(ctx context.Context, client nomadclient.ResourceClient, resource manifest.Resource, tracked storage.ManagedResource) (managedResourceResult, error) {
+	policy, err := manifest.CompileACLPolicy(resource)
+	if err != nil {
+		return managedResourceResult{}, err
+	}
+	if tracked.Address == "" {
+		existing, err := client.ObserveACLPolicy(ctx, resource.Name)
+		if err != nil {
+			return managedResourceResult{}, err
+		}
+		if existing != nil {
+			return managedResourceResult{}, fmt.Errorf("ACL policy %q already exists but is not managed by this repository", resource.Name)
+		}
+	}
+	if err := client.ApplyACLPolicy(ctx, policy); err != nil {
+		return managedResourceResult{}, err
+	}
+	return managedResourceResult{NomadID: resource.Name}, nil
+}
+
+func (aclPolicyAdapter) Delete(ctx context.Context, client nomadclient.ResourceClient, resource storage.ManagedResource) error {
+	return client.DeleteACLPolicy(ctx, resource.NomadID.String)
+}
+
+func (aclPolicyAdapter) Adopt(ctx context.Context, lookup nomadclient.ResourceLookup, resource manifest.Resource) (managedResourceResult, error) {
+	policy, err := lookup.ObserveACLPolicy(ctx, resource.Name)
+	if err != nil {
+		return managedResourceResult{}, fmt.Errorf("find ACL policy %q: %w", resource.Name, err)
+	}
+	if policy == nil {
+		return managedResourceResult{}, fmt.Errorf("ACL policy %q not found", resource.Name)
+	}
+	desired, err := manifest.CompileACLPolicy(resource)
+	if err != nil {
+		return managedResourceResult{}, err
+	}
+	if policy.Description != desired.Description || strings.TrimSpace(policy.Rules) != strings.TrimSpace(desired.Rules) {
+		return managedResourceResult{}, fmt.Errorf("ACL policy %q does not match desired bundle resource", resource.Name)
+	}
+	return managedResourceResult{NomadID: resource.Name}, nil
+}

--- a/internal/reconcile/acl_policy_adapter_test.go
+++ b/internal/reconcile/acl_policy_adapter_test.go
@@ -1,0 +1,79 @@
+package reconcile
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/brianmichel/nomad-compass/internal/manifest"
+	"github.com/brianmichel/nomad-compass/internal/plan"
+	"github.com/brianmichel/nomad-compass/internal/storage"
+)
+
+func TestACLPolicyAdapterAppliesAndObserves(t *testing.T) {
+	bundle, err := manifest.Parse([]byte(`bundle "compass" {
+  resource "acl_policy" "web" {
+    description = "web access"
+    rules {
+      namespace "default" {
+        policy = "read"
+      }
+    }
+  }
+}`), "compass.bundle.hcl")
+	if err != nil {
+		t.Fatalf("parse bundle: %v", err)
+	}
+	resource := bundle.Resources[0]
+	adapter := aclPolicyAdapter{}
+	fake := &fakeNomad{}
+	result, err := adapter.Apply(context.Background(), fake, resource, storage.ManagedResource{})
+	if err != nil || result.NomadID != "web" {
+		t.Fatalf("apply ACL policy: %v %#v", err, result)
+	}
+	observation, err := adapter.Observe(context.Background(), fake, resource, storage.ManagedResource{})
+	if err != nil || observation != (plan.Observation{Present: true, Matches: true}) {
+		t.Fatalf("observe ACL policy: %v %#v", err, observation)
+	}
+}
+
+func TestACLPolicyAdapterLifecycle(t *testing.T) {
+	bundle, err := manifest.Parse([]byte(`bundle "compass" {
+  resource "acl_policy" "web" {
+    description = "web access"
+    rules {
+      namespace "default" {
+        policy = "read"
+      }
+    }
+  }
+}`), "compass.bundle.hcl")
+	if err != nil {
+		t.Fatalf("parse bundle: %v", err)
+	}
+	resource := bundle.Resources[0]
+	fake := &fakeNomad{}
+	adapter := aclPolicyAdapter{}
+	result, err := adapter.Apply(context.Background(), fake, resource, storage.ManagedResource{})
+	if err != nil || result.NomadID != "web" {
+		t.Fatalf("apply ACL policy: %v %#v", err, result)
+	}
+	if _, err := adapter.Apply(context.Background(), fake, resource, storage.ManagedResource{}); err == nil {
+		t.Fatal("expected unmanaged ACL policy collision")
+	}
+	tracked := storage.ManagedResource{Address: resource.Address, NomadID: sql.NullString{String: result.NomadID, Valid: true}}
+	observation, err := adapter.Observe(context.Background(), fake, resource, tracked)
+	if err != nil || !observation.Matches {
+		t.Fatalf("observe ACL policy: %v %#v", err, observation)
+	}
+	if err := adapter.Replace(context.Background(), fake, resource, tracked); err != nil {
+		t.Fatalf("replace ACL policy: %v", err)
+	}
+	adopted, err := adapter.Adopt(context.Background(), fake, resource)
+	if err != nil || adopted.NomadID != result.NomadID {
+		t.Fatalf("adopt ACL policy: %v %#v", err, adopted)
+	}
+	if err := adapter.Delete(context.Background(), fake, tracked); err != nil {
+		t.Fatalf("delete ACL policy: %v", err)
+	}
+}

--- a/internal/reconcile/manager_test.go
+++ b/internal/reconcile/manager_test.go
@@ -1150,6 +1150,10 @@ type fakeNomad struct {
 	jobStatuses      map[string]*nomadclient.JobStatus
 	hostVolume       *api.HostVolume
 	aclPolicy        *api.ACLPolicy
+	namespace        *api.Namespace
+	quota            *api.QuotaSpec
+	variable         *api.Variable
+	sentinelPolicy   *api.SentinelPolicy
 	resourceCalls    []string
 }
 
@@ -1271,6 +1275,86 @@ func (f *fakeNomad) ObserveACLPolicy(_ context.Context, name string) (*api.ACLPo
 func (f *fakeNomad) DeleteACLPolicy(_ context.Context, name string) error {
 	f.resourceCalls = append(f.resourceCalls, "delete-policy:"+name)
 	f.aclPolicy = nil
+	return nil
+}
+
+func (f *fakeNomad) ApplyNamespace(_ context.Context, namespace *api.Namespace) error {
+	f.resourceCalls = append(f.resourceCalls, "namespace:"+namespace.Name)
+	copy := *namespace
+	f.namespace = &copy
+	return nil
+}
+
+func (f *fakeNomad) ObserveNamespace(_ context.Context, name string) (*api.Namespace, error) {
+	if f.namespace == nil || f.namespace.Name != name {
+		return nil, nil
+	}
+	return f.namespace, nil
+}
+
+func (f *fakeNomad) DeleteNamespace(_ context.Context, name string) error {
+	f.resourceCalls = append(f.resourceCalls, "delete-namespace:"+name)
+	f.namespace = nil
+	return nil
+}
+
+func (f *fakeNomad) ApplyQuota(_ context.Context, quota *api.QuotaSpec) error {
+	f.resourceCalls = append(f.resourceCalls, "quota:"+quota.Name)
+	copy := *quota
+	f.quota = &copy
+	return nil
+}
+
+func (f *fakeNomad) ObserveQuota(_ context.Context, name string) (*api.QuotaSpec, error) {
+	if f.quota == nil || f.quota.Name != name {
+		return nil, nil
+	}
+	return f.quota, nil
+}
+
+func (f *fakeNomad) DeleteQuota(_ context.Context, name string) error {
+	f.resourceCalls = append(f.resourceCalls, "delete-quota:"+name)
+	f.quota = nil
+	return nil
+}
+
+func (f *fakeNomad) ApplyVariable(_ context.Context, variable *api.Variable) (*api.Variable, error) {
+	f.resourceCalls = append(f.resourceCalls, "variable:"+variable.Path)
+	copy := *variable
+	f.variable = &copy
+	return &copy, nil
+}
+
+func (f *fakeNomad) ObserveVariable(_ context.Context, _, path string) (*api.Variable, error) {
+	if f.variable == nil || f.variable.Path != path {
+		return nil, nil
+	}
+	return f.variable, nil
+}
+
+func (f *fakeNomad) DeleteVariable(_ context.Context, _, path string) error {
+	f.resourceCalls = append(f.resourceCalls, "delete-variable:"+path)
+	f.variable = nil
+	return nil
+}
+
+func (f *fakeNomad) ApplySentinelPolicy(_ context.Context, policy *api.SentinelPolicy) error {
+	f.resourceCalls = append(f.resourceCalls, "sentinel:"+policy.Name)
+	copy := *policy
+	f.sentinelPolicy = &copy
+	return nil
+}
+
+func (f *fakeNomad) ObserveSentinelPolicy(_ context.Context, name string) (*api.SentinelPolicy, error) {
+	if f.sentinelPolicy == nil || f.sentinelPolicy.Name != name {
+		return nil, nil
+	}
+	return f.sentinelPolicy, nil
+}
+
+func (f *fakeNomad) DeleteSentinelPolicy(_ context.Context, name string) error {
+	f.resourceCalls = append(f.resourceCalls, "delete-sentinel:"+name)
+	f.sentinelPolicy = nil
 	return nil
 }
 

--- a/internal/reconcile/namespace_adapter.go
+++ b/internal/reconcile/namespace_adapter.go
@@ -1,0 +1,92 @@
+package reconcile
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/hashicorp/nomad/api"
+
+	"github.com/brianmichel/nomad-compass/internal/manifest"
+	"github.com/brianmichel/nomad-compass/internal/nomadclient"
+	"github.com/brianmichel/nomad-compass/internal/plan"
+	"github.com/brianmichel/nomad-compass/internal/storage"
+)
+
+type namespaceAdapter struct{}
+
+func (namespaceAdapter) Kind() string { return "namespace" }
+
+func (namespaceAdapter) Validate(resource manifest.Resource) error {
+	if _, err := manifest.CompileNamespace(resource); err != nil {
+		return fmt.Errorf("validate namespace %q: %w", resource.Address, err)
+	}
+	return nil
+}
+
+func (namespaceAdapter) Lookup(ctx context.Context, lookup nomadclient.ResourceLookup, resource manifest.Resource) (bool, error) {
+	namespace, err := lookup.ObserveNamespace(ctx, resource.Name)
+	return namespace != nil, err
+}
+
+func (namespaceAdapter) Observe(ctx context.Context, client nomadclient.ResourceClient, resource manifest.Resource, _ storage.ManagedResource) (plan.Observation, error) {
+	actual, err := client.ObserveNamespace(ctx, resource.Name)
+	if err != nil || actual == nil {
+		return plan.Observation{Present: actual != nil}, err
+	}
+	desired, err := manifest.CompileNamespace(resource)
+	if err != nil {
+		return plan.Observation{}, err
+	}
+	return plan.Observation{Present: true, Matches: namespaceEquivalent(desired, actual)}, nil
+}
+
+func (namespaceAdapter) Replace(context.Context, nomadclient.ResourceClient, manifest.Resource, storage.ManagedResource) error {
+	return nil
+}
+
+func (namespaceAdapter) Apply(ctx context.Context, client nomadclient.ResourceClient, resource manifest.Resource, tracked storage.ManagedResource) (managedResourceResult, error) {
+	desired, err := manifest.CompileNamespace(resource)
+	if err != nil {
+		return managedResourceResult{}, err
+	}
+	if tracked.Address == "" {
+		actual, err := client.ObserveNamespace(ctx, desired.Name)
+		if err != nil {
+			return managedResourceResult{}, err
+		}
+		if actual != nil {
+			return managedResourceResult{}, fmt.Errorf("namespace %q already exists but is not managed by this repository", desired.Name)
+		}
+	}
+	if err := client.ApplyNamespace(ctx, desired); err != nil {
+		return managedResourceResult{}, err
+	}
+	return managedResourceResult{NomadID: desired.Name}, nil
+}
+
+func (namespaceAdapter) Delete(ctx context.Context, client nomadclient.ResourceClient, resource storage.ManagedResource) error {
+	return client.DeleteNamespace(ctx, resource.NomadID.String)
+}
+
+func (namespaceAdapter) Adopt(ctx context.Context, lookup nomadclient.ResourceLookup, resource manifest.Resource) (managedResourceResult, error) {
+	desired, err := manifest.CompileNamespace(resource)
+	if err != nil {
+		return managedResourceResult{}, err
+	}
+	actual, err := lookup.ObserveNamespace(ctx, desired.Name)
+	if err != nil {
+		return managedResourceResult{}, fmt.Errorf("find namespace %q: %w", desired.Name, err)
+	}
+	if actual == nil {
+		return managedResourceResult{}, fmt.Errorf("namespace %q not found", desired.Name)
+	}
+	if !namespaceEquivalent(desired, actual) {
+		return managedResourceResult{}, fmt.Errorf("namespace %q does not match desired bundle resource", desired.Name)
+	}
+	return managedResourceResult{NomadID: desired.Name}, nil
+}
+
+func namespaceEquivalent(desired, actual *api.Namespace) bool {
+	return desired != nil && actual != nil && desired.Name == actual.Name && desired.Description == actual.Description && desired.Quota == actual.Quota && reflect.DeepEqual(desired.Capabilities, actual.Capabilities) && reflect.DeepEqual(desired.NodePoolConfiguration, actual.NodePoolConfiguration) && reflect.DeepEqual(desired.VaultConfiguration, actual.VaultConfiguration) && reflect.DeepEqual(desired.ConsulConfiguration, actual.ConsulConfiguration) && reflect.DeepEqual(desired.Meta, actual.Meta)
+}

--- a/internal/reconcile/namespace_adapter_test.go
+++ b/internal/reconcile/namespace_adapter_test.go
@@ -1,0 +1,43 @@
+package reconcile
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/brianmichel/nomad-compass/internal/manifest"
+	"github.com/brianmichel/nomad-compass/internal/plan"
+	"github.com/brianmichel/nomad-compass/internal/storage"
+)
+
+func TestNamespaceAdapterLifecycle(t *testing.T) {
+	bundle, err := manifest.Parse([]byte(`bundle "namespace" {
+  resource "namespace" "apps" {
+    description = "application namespace"
+  }
+}`), "namespace.bundle.hcl")
+	if err != nil {
+		t.Fatalf("parse bundle: %v", err)
+	}
+	resource := bundle.Resources[0]
+	adapter := namespaceAdapter{}
+	fake := &fakeNomad{}
+	result, err := adapter.Apply(context.Background(), fake, resource, storage.ManagedResource{})
+	if err != nil || result.NomadID != "apps" {
+		t.Fatalf("apply namespace: %v %#v", err, result)
+	}
+	tracked := storage.ManagedResource{Address: resource.Address}
+	observation, err := adapter.Observe(context.Background(), fake, resource, tracked)
+	if err != nil || observation != (plan.Observation{Present: true, Matches: true}) {
+		t.Fatalf("observe namespace: %v %#v", err, observation)
+	}
+	if _, err := adapter.Apply(context.Background(), fake, resource, storage.ManagedResource{}); err == nil {
+		t.Fatal("expected unmanaged namespace collision")
+	}
+	if _, err := adapter.Adopt(context.Background(), fake, resource); err != nil {
+		t.Fatalf("adopt namespace: %v", err)
+	}
+	if err := adapter.Delete(context.Background(), fake, storage.ManagedResource{NomadID: sql.NullString{String: result.NomadID, Valid: true}}); err != nil {
+		t.Fatalf("delete namespace: %v", err)
+	}
+}

--- a/internal/reconcile/quota_adapter.go
+++ b/internal/reconcile/quota_adapter.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sort"
+
+	"github.com/hashicorp/nomad/api"
 
 	"github.com/brianmichel/nomad-compass/internal/manifest"
 	"github.com/brianmichel/nomad-compass/internal/nomadclient"
@@ -12,6 +15,37 @@ import (
 )
 
 type quotaAdapter struct{}
+
+func quotaEquivalent(desired, actual *api.QuotaSpec) bool {
+	if desired == nil || actual == nil {
+		return false
+	}
+	left, right := normalizeQuota(desired), normalizeQuota(actual)
+	return reflect.DeepEqual(left, right)
+}
+
+func normalizeQuota(input *api.QuotaSpec) *api.QuotaSpec {
+	copy := *input
+	copy.CreateIndex, copy.ModifyIndex = 0, 0
+	copy.Limits = append([]*api.QuotaLimit(nil), input.Limits...)
+	for i, limit := range copy.Limits {
+		if limit != nil {
+			value := *limit
+			value.Hash = nil
+			copy.Limits[i] = &value
+		}
+	}
+	sort.SliceStable(copy.Limits, func(i, j int) bool {
+		if copy.Limits[i] == nil {
+			return true
+		}
+		if copy.Limits[j] == nil {
+			return false
+		}
+		return copy.Limits[i].Region < copy.Limits[j].Region
+	})
+	return &copy
+}
 
 func (quotaAdapter) Kind() string { return "quota" }
 
@@ -36,7 +70,7 @@ func (quotaAdapter) Observe(ctx context.Context, client nomadclient.ResourceClie
 	if err != nil {
 		return plan.Observation{}, err
 	}
-	return plan.Observation{Present: true, Matches: reflect.DeepEqual(desired, actual)}, nil
+	return plan.Observation{Present: true, Matches: quotaEquivalent(desired, actual)}, nil
 }
 
 func (quotaAdapter) Replace(context.Context, nomadclient.ResourceClient, manifest.Resource, storage.ManagedResource) error {
@@ -79,7 +113,7 @@ func (quotaAdapter) Adopt(ctx context.Context, lookup nomadclient.ResourceLookup
 	if actual == nil {
 		return managedResourceResult{}, fmt.Errorf("quota %q not found", desired.Name)
 	}
-	if !reflect.DeepEqual(desired, actual) {
+	if !quotaEquivalent(desired, actual) {
 		return managedResourceResult{}, fmt.Errorf("quota %q does not match desired bundle resource", desired.Name)
 	}
 	return managedResourceResult{NomadID: desired.Name}, nil

--- a/internal/reconcile/quota_adapter.go
+++ b/internal/reconcile/quota_adapter.go
@@ -1,0 +1,86 @@
+package reconcile
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/brianmichel/nomad-compass/internal/manifest"
+	"github.com/brianmichel/nomad-compass/internal/nomadclient"
+	"github.com/brianmichel/nomad-compass/internal/plan"
+	"github.com/brianmichel/nomad-compass/internal/storage"
+)
+
+type quotaAdapter struct{}
+
+func (quotaAdapter) Kind() string { return "quota" }
+
+func (quotaAdapter) Validate(resource manifest.Resource) error {
+	if _, err := manifest.CompileQuota(resource); err != nil {
+		return fmt.Errorf("validate quota %q: %w", resource.Address, err)
+	}
+	return nil
+}
+
+func (quotaAdapter) Lookup(ctx context.Context, lookup nomadclient.ResourceLookup, resource manifest.Resource) (bool, error) {
+	quota, err := lookup.ObserveQuota(ctx, resource.Name)
+	return quota != nil, err
+}
+
+func (quotaAdapter) Observe(ctx context.Context, client nomadclient.ResourceClient, resource manifest.Resource, _ storage.ManagedResource) (plan.Observation, error) {
+	actual, err := client.ObserveQuota(ctx, resource.Name)
+	if err != nil || actual == nil {
+		return plan.Observation{Present: actual != nil}, err
+	}
+	desired, err := manifest.CompileQuota(resource)
+	if err != nil {
+		return plan.Observation{}, err
+	}
+	return plan.Observation{Present: true, Matches: reflect.DeepEqual(desired, actual)}, nil
+}
+
+func (quotaAdapter) Replace(context.Context, nomadclient.ResourceClient, manifest.Resource, storage.ManagedResource) error {
+	return nil
+}
+
+func (quotaAdapter) Apply(ctx context.Context, client nomadclient.ResourceClient, resource manifest.Resource, tracked storage.ManagedResource) (managedResourceResult, error) {
+	desired, err := manifest.CompileQuota(resource)
+	if err != nil {
+		return managedResourceResult{}, err
+	}
+	if tracked.Address == "" {
+		actual, err := client.ObserveQuota(ctx, desired.Name)
+		if err != nil {
+			return managedResourceResult{}, err
+		}
+		if actual != nil {
+			return managedResourceResult{}, fmt.Errorf("quota %q already exists but is not managed by this repository", desired.Name)
+		}
+	}
+	if err := client.ApplyQuota(ctx, desired); err != nil {
+		return managedResourceResult{}, err
+	}
+	return managedResourceResult{NomadID: desired.Name}, nil
+}
+
+func (quotaAdapter) Delete(ctx context.Context, client nomadclient.ResourceClient, resource storage.ManagedResource) error {
+	return client.DeleteQuota(ctx, resource.NomadID.String)
+}
+
+func (quotaAdapter) Adopt(ctx context.Context, lookup nomadclient.ResourceLookup, resource manifest.Resource) (managedResourceResult, error) {
+	desired, err := manifest.CompileQuota(resource)
+	if err != nil {
+		return managedResourceResult{}, err
+	}
+	actual, err := lookup.ObserveQuota(ctx, desired.Name)
+	if err != nil {
+		return managedResourceResult{}, fmt.Errorf("find quota %q: %w", desired.Name, err)
+	}
+	if actual == nil {
+		return managedResourceResult{}, fmt.Errorf("quota %q not found", desired.Name)
+	}
+	if !reflect.DeepEqual(desired, actual) {
+		return managedResourceResult{}, fmt.Errorf("quota %q does not match desired bundle resource", desired.Name)
+	}
+	return managedResourceResult{NomadID: desired.Name}, nil
+}

--- a/internal/reconcile/quota_adapter_test.go
+++ b/internal/reconcile/quota_adapter_test.go
@@ -1,0 +1,46 @@
+package reconcile
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/brianmichel/nomad-compass/internal/manifest"
+	"github.com/brianmichel/nomad-compass/internal/plan"
+	"github.com/brianmichel/nomad-compass/internal/storage"
+)
+
+func TestQuotaAdapterLifecycle(t *testing.T) {
+	bundle, err := manifest.Parse([]byte(`bundle "quota" {
+  resource "quota" "apps" {
+    description = "application quota"
+    limit {
+      region = "global"
+      region_limit {
+        cpu = 1000
+        memory = 512
+      }
+    }
+  }
+}`), "quota.bundle.hcl")
+	if err != nil {
+		t.Fatalf("parse bundle: %v", err)
+	}
+	resource := bundle.Resources[0]
+	adapter := quotaAdapter{}
+	fake := &fakeNomad{}
+	result, err := adapter.Apply(context.Background(), fake, resource, storage.ManagedResource{})
+	if err != nil || result.NomadID != "apps" {
+		t.Fatalf("apply quota: %v %#v", err, result)
+	}
+	observation, err := adapter.Observe(context.Background(), fake, resource, storage.ManagedResource{})
+	if err != nil || observation != (plan.Observation{Present: true, Matches: true}) {
+		t.Fatalf("observe quota: %v %#v", err, observation)
+	}
+	if _, err := adapter.Adopt(context.Background(), fake, resource); err != nil {
+		t.Fatalf("adopt quota: %v", err)
+	}
+	if err := adapter.Delete(context.Background(), fake, storage.ManagedResource{NomadID: sql.NullString{String: result.NomadID, Valid: true}}); err != nil {
+		t.Fatalf("delete quota: %v", err)
+	}
+}

--- a/internal/reconcile/resource_adapter.go
+++ b/internal/reconcile/resource_adapter.go
@@ -1,0 +1,44 @@
+package reconcile
+
+import (
+	"context"
+
+	"github.com/brianmichel/nomad-compass/internal/manifest"
+	"github.com/brianmichel/nomad-compass/internal/nomadclient"
+	"github.com/brianmichel/nomad-compass/internal/plan"
+	"github.com/brianmichel/nomad-compass/internal/storage"
+)
+
+// managedResourceAdapter owns the lifecycle rules for one Nomad resource kind.
+// Keeping one concrete adapter per kind makes decoding, comparison, adoption,
+// replacement, and deletion changes local to that resource.
+type managedResourceAdapter interface {
+	Kind() string
+	Validate(manifest.Resource) error
+	Lookup(context.Context, nomadclient.ResourceLookup, manifest.Resource) (bool, error)
+	Observe(context.Context, nomadclient.ResourceClient, manifest.Resource, storage.ManagedResource) (plan.Observation, error)
+	Replace(context.Context, nomadclient.ResourceClient, manifest.Resource, storage.ManagedResource) error
+	Apply(context.Context, nomadclient.ResourceClient, manifest.Resource, storage.ManagedResource) (managedResourceResult, error)
+	Adopt(context.Context, nomadclient.ResourceLookup, manifest.Resource) (managedResourceResult, error)
+	Delete(context.Context, nomadclient.ResourceClient, storage.ManagedResource) error
+}
+
+type managedResourceResult struct {
+	NomadID   string
+	Namespace string
+	Subtype   string
+}
+
+var managedResourceAdapters = map[string]managedResourceAdapter{
+	"volume":          volumeAdapter{},
+	"acl_policy":      aclPolicyAdapter{},
+	"namespace":       namespaceAdapter{},
+	"quota":           quotaAdapter{},
+	"variable":        variableAdapter{},
+	"sentinel_policy": sentinelPolicyAdapter{},
+}
+
+func adapterFor(kind string) (managedResourceAdapter, bool) {
+	adapter, ok := managedResourceAdapters[kind]
+	return adapter, ok
+}

--- a/internal/reconcile/resource_adapter_test.go
+++ b/internal/reconcile/resource_adapter_test.go
@@ -1,0 +1,12 @@
+package reconcile
+
+import "testing"
+
+func TestManagedResourceAdaptersCoverSupportedNonJobKinds(t *testing.T) {
+	for _, kind := range []string{"volume", "acl_policy", "namespace", "quota", "variable", "sentinel_policy"} {
+		adapter, ok := adapterFor(kind)
+		if !ok || adapter.Kind() != kind {
+			t.Fatalf("missing adapter for %q: %#v", kind, adapter)
+		}
+	}
+}

--- a/internal/reconcile/sentinel_policy_adapter.go
+++ b/internal/reconcile/sentinel_policy_adapter.go
@@ -1,0 +1,86 @@
+package reconcile
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/brianmichel/nomad-compass/internal/manifest"
+	"github.com/brianmichel/nomad-compass/internal/nomadclient"
+	"github.com/brianmichel/nomad-compass/internal/plan"
+	"github.com/brianmichel/nomad-compass/internal/storage"
+)
+
+type sentinelPolicyAdapter struct{}
+
+func (sentinelPolicyAdapter) Kind() string { return "sentinel_policy" }
+
+func (sentinelPolicyAdapter) Validate(resource manifest.Resource) error {
+	if _, err := manifest.CompileSentinelPolicy(resource); err != nil {
+		return fmt.Errorf("validate Sentinel policy %q: %w", resource.Address, err)
+	}
+	return nil
+}
+
+func (sentinelPolicyAdapter) Lookup(ctx context.Context, lookup nomadclient.ResourceLookup, resource manifest.Resource) (bool, error) {
+	policy, err := lookup.ObserveSentinelPolicy(ctx, resource.Name)
+	return policy != nil, err
+}
+
+func (sentinelPolicyAdapter) Observe(ctx context.Context, client nomadclient.ResourceClient, resource manifest.Resource, _ storage.ManagedResource) (plan.Observation, error) {
+	actual, err := client.ObserveSentinelPolicy(ctx, resource.Name)
+	if err != nil || actual == nil {
+		return plan.Observation{Present: actual != nil}, err
+	}
+	desired, err := manifest.CompileSentinelPolicy(resource)
+	if err != nil {
+		return plan.Observation{}, err
+	}
+	return plan.Observation{Present: true, Matches: reflect.DeepEqual(desired, actual)}, nil
+}
+
+func (sentinelPolicyAdapter) Replace(context.Context, nomadclient.ResourceClient, manifest.Resource, storage.ManagedResource) error {
+	return nil
+}
+
+func (sentinelPolicyAdapter) Apply(ctx context.Context, client nomadclient.ResourceClient, resource manifest.Resource, tracked storage.ManagedResource) (managedResourceResult, error) {
+	desired, err := manifest.CompileSentinelPolicy(resource)
+	if err != nil {
+		return managedResourceResult{}, err
+	}
+	if tracked.Address == "" {
+		actual, err := client.ObserveSentinelPolicy(ctx, desired.Name)
+		if err != nil {
+			return managedResourceResult{}, err
+		}
+		if actual != nil {
+			return managedResourceResult{}, fmt.Errorf("Sentinel policy %q already exists but is not managed by this repository", desired.Name)
+		}
+	}
+	if err := client.ApplySentinelPolicy(ctx, desired); err != nil {
+		return managedResourceResult{}, err
+	}
+	return managedResourceResult{NomadID: desired.Name}, nil
+}
+
+func (sentinelPolicyAdapter) Delete(ctx context.Context, client nomadclient.ResourceClient, resource storage.ManagedResource) error {
+	return client.DeleteSentinelPolicy(ctx, resource.NomadID.String)
+}
+
+func (sentinelPolicyAdapter) Adopt(ctx context.Context, lookup nomadclient.ResourceLookup, resource manifest.Resource) (managedResourceResult, error) {
+	desired, err := manifest.CompileSentinelPolicy(resource)
+	if err != nil {
+		return managedResourceResult{}, err
+	}
+	actual, err := lookup.ObserveSentinelPolicy(ctx, desired.Name)
+	if err != nil {
+		return managedResourceResult{}, fmt.Errorf("find Sentinel policy %q: %w", desired.Name, err)
+	}
+	if actual == nil {
+		return managedResourceResult{}, fmt.Errorf("Sentinel policy %q not found", desired.Name)
+	}
+	if !reflect.DeepEqual(desired, actual) {
+		return managedResourceResult{}, fmt.Errorf("Sentinel policy %q does not match desired bundle resource", desired.Name)
+	}
+	return managedResourceResult{NomadID: desired.Name}, nil
+}

--- a/internal/reconcile/sentinel_policy_adapter.go
+++ b/internal/reconcile/sentinel_policy_adapter.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/hashicorp/nomad/api"
+
 	"github.com/brianmichel/nomad-compass/internal/manifest"
 	"github.com/brianmichel/nomad-compass/internal/nomadclient"
 	"github.com/brianmichel/nomad-compass/internal/plan"
@@ -12,6 +14,15 @@ import (
 )
 
 type sentinelPolicyAdapter struct{}
+
+func sentinelEquivalent(desired, actual *api.SentinelPolicy) bool {
+	if desired == nil || actual == nil {
+		return false
+	}
+	left, right := *desired, *actual
+	left.CreateIndex, left.ModifyIndex, right.CreateIndex, right.ModifyIndex = 0, 0, 0, 0
+	return reflect.DeepEqual(left, right)
+}
 
 func (sentinelPolicyAdapter) Kind() string { return "sentinel_policy" }
 
@@ -36,7 +47,7 @@ func (sentinelPolicyAdapter) Observe(ctx context.Context, client nomadclient.Res
 	if err != nil {
 		return plan.Observation{}, err
 	}
-	return plan.Observation{Present: true, Matches: reflect.DeepEqual(desired, actual)}, nil
+	return plan.Observation{Present: true, Matches: sentinelEquivalent(desired, actual)}, nil
 }
 
 func (sentinelPolicyAdapter) Replace(context.Context, nomadclient.ResourceClient, manifest.Resource, storage.ManagedResource) error {
@@ -79,7 +90,7 @@ func (sentinelPolicyAdapter) Adopt(ctx context.Context, lookup nomadclient.Resou
 	if actual == nil {
 		return managedResourceResult{}, fmt.Errorf("Sentinel policy %q not found", desired.Name)
 	}
-	if !reflect.DeepEqual(desired, actual) {
+	if !sentinelEquivalent(desired, actual) {
 		return managedResourceResult{}, fmt.Errorf("Sentinel policy %q does not match desired bundle resource", desired.Name)
 	}
 	return managedResourceResult{NomadID: desired.Name}, nil

--- a/internal/reconcile/sentinel_policy_adapter_test.go
+++ b/internal/reconcile/sentinel_policy_adapter_test.go
@@ -1,0 +1,41 @@
+package reconcile
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/brianmichel/nomad-compass/internal/manifest"
+	"github.com/brianmichel/nomad-compass/internal/plan"
+	"github.com/brianmichel/nomad-compass/internal/storage"
+)
+
+func TestSentinelPolicyAdapterLifecycle(t *testing.T) {
+	bundle, err := manifest.Parse([]byte(`bundle "sentinel" {
+  resource "sentinel_policy" "safe" {
+    scope = "submit-job"
+    enforcement_level = "soft-mandatory"
+    policy = "main = rule { true }"
+  }
+}`), "sentinel.bundle.hcl")
+	if err != nil {
+		t.Fatalf("parse bundle: %v", err)
+	}
+	resource := bundle.Resources[0]
+	adapter := sentinelPolicyAdapter{}
+	fake := &fakeNomad{}
+	result, err := adapter.Apply(context.Background(), fake, resource, storage.ManagedResource{})
+	if err != nil || result.NomadID != "safe" {
+		t.Fatalf("apply Sentinel policy: %v %#v", err, result)
+	}
+	observation, err := adapter.Observe(context.Background(), fake, resource, storage.ManagedResource{})
+	if err != nil || observation != (plan.Observation{Present: true, Matches: true}) {
+		t.Fatalf("observe Sentinel policy: %v %#v", err, observation)
+	}
+	if _, err := adapter.Adopt(context.Background(), fake, resource); err != nil {
+		t.Fatalf("adopt Sentinel policy: %v", err)
+	}
+	if err := adapter.Delete(context.Background(), fake, storage.ManagedResource{NomadID: sql.NullString{String: result.NomadID, Valid: true}}); err != nil {
+		t.Fatalf("delete Sentinel policy: %v", err)
+	}
+}

--- a/internal/reconcile/variable_adapter.go
+++ b/internal/reconcile/variable_adapter.go
@@ -45,7 +45,26 @@ func (variableAdapter) Observe(ctx context.Context, client nomadclient.ResourceC
 	return plan.Observation{Present: true, Matches: variableEquivalent(desired, actual)}, nil
 }
 
-func (variableAdapter) Replace(context.Context, nomadclient.ResourceClient, manifest.Resource, storage.ManagedResource) error {
+func (variableAdapter) Replace(ctx context.Context, client nomadclient.ResourceClient, resource manifest.Resource, tracked storage.ManagedResource) error {
+	desired, err := manifest.CompileVariable(resource)
+	if err != nil {
+		return err
+	}
+	oldNamespace, oldPath := tracked.Namespace.String, tracked.NomadID.String
+	if oldNamespace == desired.Namespace && oldPath == desired.Path {
+		return nil
+	}
+	if resource.DeleteMode != manifest.DeleteModeAllow {
+		return fmt.Errorf("variable identity changes are protected; set delete = %q to allow replacement", manifest.DeleteModeAllow)
+	}
+	if existing, err := client.ObserveVariable(ctx, desired.Namespace, desired.Path); err != nil {
+		return err
+	} else if existing != nil {
+		return fmt.Errorf("variable %q already exists at the replacement identity", desired.Path)
+	}
+	if err := client.DeleteVariable(ctx, oldNamespace, oldPath); err != nil {
+		return fmt.Errorf("delete old variable identity: %w", err)
+	}
 	return nil
 }
 

--- a/internal/reconcile/variable_adapter.go
+++ b/internal/reconcile/variable_adapter.go
@@ -1,0 +1,100 @@
+package reconcile
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/hashicorp/nomad/api"
+
+	"github.com/brianmichel/nomad-compass/internal/manifest"
+	"github.com/brianmichel/nomad-compass/internal/nomadclient"
+	"github.com/brianmichel/nomad-compass/internal/plan"
+	"github.com/brianmichel/nomad-compass/internal/storage"
+)
+
+type variableAdapter struct{}
+
+func (variableAdapter) Kind() string { return "variable" }
+
+func (variableAdapter) Validate(resource manifest.Resource) error {
+	if _, err := manifest.CompileVariable(resource); err != nil {
+		return fmt.Errorf("validate variable %q: %w", resource.Address, err)
+	}
+	return nil
+}
+
+func (variableAdapter) Lookup(ctx context.Context, lookup nomadclient.ResourceLookup, resource manifest.Resource) (bool, error) {
+	variable, err := manifest.CompileVariable(resource)
+	if err != nil {
+		return false, err
+	}
+	found, err := lookup.ObserveVariable(ctx, variable.Namespace, variable.Path)
+	return found != nil, err
+}
+
+func (variableAdapter) Observe(ctx context.Context, client nomadclient.ResourceClient, resource manifest.Resource, _ storage.ManagedResource) (plan.Observation, error) {
+	desired, err := manifest.CompileVariable(resource)
+	if err != nil {
+		return plan.Observation{}, err
+	}
+	actual, err := client.ObserveVariable(ctx, desired.Namespace, desired.Path)
+	if err != nil || actual == nil {
+		return plan.Observation{Present: actual != nil}, err
+	}
+	return plan.Observation{Present: true, Matches: variableEquivalent(desired, actual)}, nil
+}
+
+func (variableAdapter) Replace(context.Context, nomadclient.ResourceClient, manifest.Resource, storage.ManagedResource) error {
+	return nil
+}
+
+func (variableAdapter) Apply(ctx context.Context, client nomadclient.ResourceClient, resource manifest.Resource, tracked storage.ManagedResource) (managedResourceResult, error) {
+	desired, err := manifest.CompileVariable(resource)
+	if err != nil {
+		return managedResourceResult{}, err
+	}
+	if tracked.Address == "" {
+		actual, err := client.ObserveVariable(ctx, desired.Namespace, desired.Path)
+		if err != nil {
+			return managedResourceResult{}, err
+		}
+		if actual != nil {
+			return managedResourceResult{}, fmt.Errorf("variable %q already exists but is not managed by this repository", desired.Path)
+		}
+	}
+	actual, err := client.ApplyVariable(ctx, desired)
+	if err != nil {
+		return managedResourceResult{}, err
+	}
+	if actual == nil {
+		actual = desired
+	}
+	return managedResourceResult{NomadID: actual.Path, Namespace: actual.Namespace}, nil
+}
+
+func (variableAdapter) Delete(ctx context.Context, client nomadclient.ResourceClient, resource storage.ManagedResource) error {
+	return client.DeleteVariable(ctx, resource.Namespace.String, resource.NomadID.String)
+}
+
+func (variableAdapter) Adopt(ctx context.Context, lookup nomadclient.ResourceLookup, resource manifest.Resource) (managedResourceResult, error) {
+	desired, err := manifest.CompileVariable(resource)
+	if err != nil {
+		return managedResourceResult{}, err
+	}
+	actual, err := lookup.ObserveVariable(ctx, desired.Namespace, desired.Path)
+	if err != nil {
+		return managedResourceResult{}, fmt.Errorf("find variable %q: %w", desired.Path, err)
+	}
+	if actual == nil {
+		return managedResourceResult{}, fmt.Errorf("variable %q not found", desired.Path)
+	}
+	if !variableEquivalent(desired, actual) {
+		return managedResourceResult{}, fmt.Errorf("variable %q does not match desired bundle resource", desired.Path)
+	}
+	return managedResourceResult{NomadID: actual.Path, Namespace: actual.Namespace}, nil
+}
+
+func variableEquivalent(desired, actual *api.Variable) bool {
+	return desired != nil && actual != nil && desired.Namespace == actual.Namespace && desired.Path == actual.Path && reflect.DeepEqual(desired.Items, actual.Items)
+}

--- a/internal/reconcile/variable_adapter_test.go
+++ b/internal/reconcile/variable_adapter_test.go
@@ -1,0 +1,46 @@
+package reconcile
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/brianmichel/nomad-compass/internal/manifest"
+	"github.com/brianmichel/nomad-compass/internal/plan"
+	"github.com/brianmichel/nomad-compass/internal/storage"
+)
+
+func TestVariableAdapterLifecycle(t *testing.T) {
+	bundle, err := manifest.Parse([]byte(`bundle "variable" {
+  resource "variable" "apps/config" {
+    namespace = "default"
+    items = {
+      environment = "test"
+    }
+  }
+}`), "variable.bundle.hcl")
+	if err != nil {
+		t.Fatalf("parse bundle: %v", err)
+	}
+	resource := bundle.Resources[0]
+	adapter := variableAdapter{}
+	fake := &fakeNomad{}
+	result, err := adapter.Apply(context.Background(), fake, resource, storage.ManagedResource{})
+	if err != nil || result.NomadID != "apps/config" {
+		t.Fatalf("apply variable: %v %#v", err, result)
+	}
+	tracked := storage.ManagedResource{Address: resource.Address, NomadID: sql.NullString{String: result.NomadID, Valid: true}, Namespace: sql.NullString{String: result.Namespace, Valid: true}}
+	observation, err := adapter.Observe(context.Background(), fake, resource, tracked)
+	if err != nil || observation != (plan.Observation{Present: true, Matches: true}) {
+		t.Fatalf("observe variable: %v %#v", err, observation)
+	}
+	if _, err := adapter.Apply(context.Background(), fake, resource, storage.ManagedResource{}); err == nil {
+		t.Fatal("expected unmanaged variable collision")
+	}
+	if _, err := adapter.Adopt(context.Background(), fake, resource); err != nil {
+		t.Fatalf("adopt variable: %v", err)
+	}
+	if err := adapter.Delete(context.Background(), fake, tracked); err != nil {
+		t.Fatalf("delete variable: %v", err)
+	}
+}

--- a/internal/reconcile/volume_adapter.go
+++ b/internal/reconcile/volume_adapter.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
-	"strings"
 
 	"github.com/hashicorp/nomad/api"
 
@@ -15,36 +14,6 @@ import (
 	"github.com/brianmichel/nomad-compass/internal/plan"
 	"github.com/brianmichel/nomad-compass/internal/storage"
 )
-
-// managedResourceAdapter concentrates one Nomad resource kind's native
-// decoding, observation, application, and adoption rules. Jobs remain on the
-// existing jobspec path because their lifecycle includes deployment planning.
-type managedResourceAdapter interface {
-	Kind() string
-	Validate(manifest.Resource) error
-	Lookup(context.Context, nomadclient.ResourceLookup, manifest.Resource) (bool, error)
-	Observe(context.Context, nomadclient.ResourceClient, manifest.Resource, storage.ManagedResource) (plan.Observation, error)
-	Replace(context.Context, nomadclient.ResourceClient, manifest.Resource, storage.ManagedResource) error
-	Apply(context.Context, nomadclient.ResourceClient, manifest.Resource, storage.ManagedResource) (managedResourceResult, error)
-	Adopt(context.Context, nomadclient.ResourceLookup, manifest.Resource) (managedResourceResult, error)
-	Delete(context.Context, nomadclient.ResourceClient, storage.ManagedResource) error
-}
-
-type managedResourceResult struct {
-	NomadID   string
-	Namespace string
-	Subtype   string
-}
-
-var managedResourceAdapters = map[string]managedResourceAdapter{
-	"volume":     volumeAdapter{},
-	"acl_policy": aclPolicyAdapter{},
-}
-
-func adapterFor(kind string) (managedResourceAdapter, bool) {
-	adapter, ok := managedResourceAdapters[kind]
-	return adapter, ok
-}
 
 type volumeAdapter struct{}
 
@@ -175,81 +144,6 @@ func (volumeAdapter) Adopt(ctx context.Context, lookup nomadclient.ResourceLooku
 		return managedResourceResult{}, fmt.Errorf("CSI volume %q does not match desired bundle resource", resource.Name)
 	}
 	return managedResourceResult{NomadID: volume.ID, Namespace: volume.Namespace, Subtype: "csi"}, nil
-}
-
-type aclPolicyAdapter struct{}
-
-func (aclPolicyAdapter) Kind() string { return "acl_policy" }
-
-func (aclPolicyAdapter) Validate(resource manifest.Resource) error {
-	if _, err := manifest.CompileACLPolicy(resource); err != nil {
-		return fmt.Errorf("validate bundle ACL policy %q: %w", resource.Address, err)
-	}
-	return nil
-}
-
-func (aclPolicyAdapter) Lookup(ctx context.Context, lookup nomadclient.ResourceLookup, resource manifest.Resource) (bool, error) {
-	policy, err := lookup.ObserveACLPolicy(ctx, resource.Name)
-	return policy != nil, err
-}
-
-func (aclPolicyAdapter) Observe(ctx context.Context, client nomadclient.ResourceClient, resource manifest.Resource, _ storage.ManagedResource) (plan.Observation, error) {
-	policy, err := client.ObserveACLPolicy(ctx, resource.Name)
-	if err != nil || policy == nil {
-		return plan.Observation{Present: policy != nil}, err
-	}
-	desired, err := manifest.CompileACLPolicy(resource)
-	if err != nil {
-		return plan.Observation{}, err
-	}
-	matches := policy.Description == desired.Description && strings.TrimSpace(policy.Rules) == strings.TrimSpace(desired.Rules)
-	return plan.Observation{Present: true, Matches: matches}, nil
-}
-
-func (aclPolicyAdapter) Replace(context.Context, nomadclient.ResourceClient, manifest.Resource, storage.ManagedResource) error {
-	return nil
-}
-
-func (aclPolicyAdapter) Apply(ctx context.Context, client nomadclient.ResourceClient, resource manifest.Resource, tracked storage.ManagedResource) (managedResourceResult, error) {
-	policy, err := manifest.CompileACLPolicy(resource)
-	if err != nil {
-		return managedResourceResult{}, err
-	}
-	if tracked.Address == "" {
-		existing, err := client.ObserveACLPolicy(ctx, resource.Name)
-		if err != nil {
-			return managedResourceResult{}, err
-		}
-		if existing != nil {
-			return managedResourceResult{}, fmt.Errorf("ACL policy %q already exists but is not managed by this repository", resource.Name)
-		}
-	}
-	if err := client.ApplyACLPolicy(ctx, policy); err != nil {
-		return managedResourceResult{}, err
-	}
-	return managedResourceResult{NomadID: resource.Name}, nil
-}
-
-func (aclPolicyAdapter) Delete(ctx context.Context, client nomadclient.ResourceClient, resource storage.ManagedResource) error {
-	return client.DeleteACLPolicy(ctx, resource.NomadID.String)
-}
-
-func (aclPolicyAdapter) Adopt(ctx context.Context, lookup nomadclient.ResourceLookup, resource manifest.Resource) (managedResourceResult, error) {
-	policy, err := lookup.ObserveACLPolicy(ctx, resource.Name)
-	if err != nil {
-		return managedResourceResult{}, fmt.Errorf("find ACL policy %q: %w", resource.Name, err)
-	}
-	if policy == nil {
-		return managedResourceResult{}, fmt.Errorf("ACL policy %q not found", resource.Name)
-	}
-	desired, err := manifest.CompileACLPolicy(resource)
-	if err != nil {
-		return managedResourceResult{}, err
-	}
-	if policy.Description != desired.Description || strings.TrimSpace(policy.Rules) != strings.TrimSpace(desired.Rules) {
-		return managedResourceResult{}, fmt.Errorf("ACL policy %q does not match desired bundle resource", resource.Name)
-	}
-	return managedResourceResult{NomadID: resource.Name}, nil
 }
 
 func observeVolumeDrift(ctx context.Context, client nomadclient.ResourceClient, resource manifest.Resource, tracked storage.ManagedResource) (drifted, present bool, err error) {

--- a/internal/reconcile/volume_adapter_test.go
+++ b/internal/reconcile/volume_adapter_test.go
@@ -12,42 +12,6 @@ import (
 	"github.com/brianmichel/nomad-compass/internal/storage"
 )
 
-func TestManagedResourceAdaptersCoverSupportedNonJobKinds(t *testing.T) {
-	for _, kind := range []string{"volume", "acl_policy"} {
-		adapter, ok := adapterFor(kind)
-		if !ok || adapter.Kind() != kind {
-			t.Fatalf("missing adapter for %q: %#v", kind, adapter)
-		}
-	}
-}
-
-func TestACLPolicyAdapterAppliesAndObserves(t *testing.T) {
-	bundle, err := manifest.Parse([]byte(`bundle "compass" {
-  resource "acl_policy" "web" {
-    description = "web access"
-    rules {
-      namespace "default" {
-        policy = "read"
-      }
-    }
-  }
-}`), "compass.bundle.hcl")
-	if err != nil {
-		t.Fatalf("parse bundle: %v", err)
-	}
-	resource := bundle.Resources[0]
-	adapter := aclPolicyAdapter{}
-	fake := &fakeNomad{}
-	result, err := adapter.Apply(context.Background(), fake, resource, storage.ManagedResource{})
-	if err != nil || result.NomadID != "web" {
-		t.Fatalf("apply ACL policy: %v %#v", err, result)
-	}
-	observation, err := adapter.Observe(context.Background(), fake, resource, storage.ManagedResource{})
-	if err != nil || observation != (plan.Observation{Present: true, Matches: true}) {
-		t.Fatalf("observe ACL policy: %v %#v", err, observation)
-	}
-}
-
 func TestVolumeAdapterRejectsUnmanagedCollision(t *testing.T) {
 	bundle, err := manifest.Parse([]byte(`bundle "compass" {
   resource "volume" "data" {
@@ -115,47 +79,6 @@ func TestVolumeAdapterLifecycle(t *testing.T) {
 	tracked.NomadID = sql.NullString{String: result.NomadID, Valid: true}
 	if err := adapter.Delete(context.Background(), fake, tracked); err != nil {
 		t.Fatalf("delete volume: %v", err)
-	}
-}
-
-func TestACLPolicyAdapterLifecycle(t *testing.T) {
-	bundle, err := manifest.Parse([]byte(`bundle "compass" {
-  resource "acl_policy" "web" {
-    description = "web access"
-    rules {
-      namespace "default" {
-        policy = "read"
-      }
-    }
-  }
-}`), "compass.bundle.hcl")
-	if err != nil {
-		t.Fatalf("parse bundle: %v", err)
-	}
-	resource := bundle.Resources[0]
-	fake := &fakeNomad{}
-	adapter := aclPolicyAdapter{}
-	result, err := adapter.Apply(context.Background(), fake, resource, storage.ManagedResource{})
-	if err != nil || result.NomadID != "web" {
-		t.Fatalf("apply ACL policy: %v %#v", err, result)
-	}
-	if _, err := adapter.Apply(context.Background(), fake, resource, storage.ManagedResource{}); err == nil {
-		t.Fatal("expected unmanaged ACL policy collision")
-	}
-	tracked := storage.ManagedResource{Address: resource.Address, NomadID: sql.NullString{String: result.NomadID, Valid: true}}
-	observation, err := adapter.Observe(context.Background(), fake, resource, tracked)
-	if err != nil || !observation.Matches {
-		t.Fatalf("observe ACL policy: %v %#v", err, observation)
-	}
-	if err := adapter.Replace(context.Background(), fake, resource, tracked); err != nil {
-		t.Fatalf("replace ACL policy: %v", err)
-	}
-	adopted, err := adapter.Adopt(context.Background(), fake, resource)
-	if err != nil || adopted.NomadID != result.NomadID {
-		t.Fatalf("adopt ACL policy: %v %#v", err, adopted)
-	}
-	if err := adapter.Delete(context.Background(), fake, tracked); err != nil {
-		t.Fatalf("delete ACL policy: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
Adds dedicated adapters and Nomad clients for volumes, ACL policies, namespaces, quotas, variables, and Sentinel policies.

## Review focus
- One adapter per resource kind
- Apply, observe, replace, adopt, and delete semantics
- Protected/destructive resource behavior

Quota and Sentinel endpoints require Nomad Enterprise; their lifecycle tests use fakes.

## Stack
Builds on #23.

## Validation
`go test ./...`
`go vet ./...`